### PR TITLE
ble: fixing ios time not updated

### DIFF
--- a/app/src/applications/settings/settings_app.c
+++ b/app/src/applications/settings/settings_app.c
@@ -142,7 +142,7 @@ static lv_settings_item_t bluetooth_page_items[] = {
     },
     {
         .type = LV_SETTINGS_TYPE_SWITCH,
-        .icon = "",
+        .icon = NULL,
         .change_callback = on_aoa_enable_changed,
         .item = {
             .sw = {

--- a/app/src/applications/settings/settings_ui.c
+++ b/app/src/applications/settings/settings_ui.c
@@ -49,8 +49,8 @@ static lv_obj_t *create_text(lv_obj_t *parent, const char *icon, const char *txt
     lv_obj_t *label = NULL;
 
     if (icon) {
-        img = lv_img_create(obj);
-        lv_img_set_src(img, icon);
+        img = lv_image_create(obj);
+        lv_image_set_src(img, icon);
     }
 
     if (txt) {
@@ -168,7 +168,7 @@ void lv_settings_create(lv_obj_t *root, lv_settings_page_t *pages, uint8_t num_p
     // Border around selected menu row when focused
     lv_style_init(&outline_primary);
     lv_style_set_border_color(&outline_primary, lv_color_hex(0xF99B7D));
-    lv_style_set_border_width(&outline_primary, lv_display_dpx(lv_disp_get_next(NULL), 3));
+    lv_style_set_border_width(&outline_primary, lv_display_dpx(lv_display_get_next(NULL), 3));
     lv_style_set_border_opa(&outline_primary, LV_OPA_50);
     lv_style_set_border_side(&outline_primary, LV_BORDER_SIDE_BOTTOM);
 

--- a/app/src/ble/ble_cts.c
+++ b/app/src/ble/ble_cts.c
@@ -134,13 +134,17 @@ static void discover_completed_cb(struct bt_gatt_dm *dm, void *ctx)
     } else {
         has_cts = true;
 
-        if (bt_conn_get_security(cts_c.conn) >= BT_SECURITY_L2) {
+        err = bt_conn_get_security(cts_c.conn);
+
+        if (err >= BT_SECURITY_L2) {
             enable_notifications();
 
             err = bt_cts_read_current_time(&cts_c, read_current_time_cb);
             if (err) {
                 LOG_ERR("Failed reading current time (err: %d)", err);
             }
+        } else {
+            LOG_WRN("Link not secured (security %d), enable pairing and try again", err);
         }
     }
 


### PR DESCRIPTION
fixing time not updated on ios although bluetooth connection is established. 
Turns out the security level is < `BT_SECURITY_L2`, so my attempt at fixing it is to manually call `bt_conn_set_security`. 
This worked when I test pairing with my iPhone, but unsure if this is the right fix. Still need to test with other iPhone if possible.

Fix for #406 