### PR TITLE
Fix sensor fusion and compass not working due to imu returning error.

### DIFF
--- a/app/drivers/sensor/bmi270/private/bosch_bmi270_config.c
+++ b/app/drivers/sensor/bmi270/private/bosch_bmi270_config.c
@@ -587,6 +587,7 @@ int bmi2_disable_feature(const struct device *p_dev, uint8_t feature)
 
 int bmi2_enable_feature(const struct device *p_dev, uint8_t feature, bool int_en)
 {
+    int8_t rslt;
     uint16_t int_status;
     uint8_t feature_disable;
     struct bmi2_sens_int_config cfg;
@@ -611,8 +612,11 @@ int bmi2_enable_feature(const struct device *p_dev, uint8_t feature, bool int_en
         cfg.hw_int_pin = BMI2_INT_NONE;
     }
     cfg.type = feature;
-
-    if (bmi270_map_feat_int(&cfg, 1, &data->bmi2) != BMI2_OK) {
+    
+    rslt = bmi270_map_feat_int(&cfg, 1, &data->bmi2);
+    // If interrupt is not enabled and interrupt mapping failed due to invalid sensor, it's fine.
+    // As we never tried to enable an interrupt for this specific feature.
+    if ((rslt != BMI2_OK) && !(rslt == BMI2_E_INVALID_SENSOR && !int_en)) {
         return -EFAULT;
     }
 


### PR DESCRIPTION
The error is not correct as we never did something invalid, i.e. try to enable an int on a feature not supporting int. So catch that case and return OK for it.