### PR TITLE
watchface: fix flipping from 2 to 1 digit error

### DIFF
--- a/app/src/ui/watchfaces/107_2_dial/zsw_watchface_107_2_dial_ui.c
+++ b/app/src/ui/watchfaces/107_2_dial/zsw_watchface_107_2_dial_ui.c
@@ -16,7 +16,6 @@
 
 LOG_MODULE_REGISTER(watchface_107_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_107_2_dial;
 static lv_obj_t *face_107_2_dial = NULL;
 static watchface_app_evt_listener ui_107_2_dial_evt_cb;
 static zsw_ui_notification_area_t *zsw_ui_notifications_area;
@@ -137,20 +136,15 @@ const void *face_107_2_dial_12_85153_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_107_2_dial_remove(void)
@@ -194,50 +188,46 @@ static void watchface_107_2_dial_set_datetime(int day_of_week, int date, int day
     month += 1;
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_107_2_dial_2_58391, face_107_2_dial_2_58391_group[(day / 1) % 10]);
+        lv_image_set_src(face_107_2_dial_2_58391, face_107_2_dial_2_58391_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_107_2_dial_3_58391, face_107_2_dial_2_58391_group[(day / 10) % 10]);
+        lv_image_set_src(face_107_2_dial_3_58391, face_107_2_dial_2_58391_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        last_month = setPlaceValue(last_month, 1, getPlaceValue(month, 1));
-        lv_img_set_src(face_107_2_dial_4_58391, face_107_2_dial_2_58391_group[(month / 1) % 10]);
+        lv_image_set_src(face_107_2_dial_4_58391, face_107_2_dial_2_58391_group[(month / 1) % 10]);
     }
 
     if (getPlaceValue(last_month, 2) != getPlaceValue(month, 2)) {
-        last_month = setPlaceValue(last_month, 2, getPlaceValue(month, 2));
-        lv_img_set_src(face_107_2_dial_5_58391, face_107_2_dial_2_58391_group[(month / 10) % 10]);
+        lv_image_set_src(face_107_2_dial_5_58391, face_107_2_dial_2_58391_group[(month / 10) % 10]);
     }
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_107_2_dial_7_60782, face_107_2_dial_7_60782_group[(hour / 1) % 10]);
+        lv_image_set_src(face_107_2_dial_7_60782, face_107_2_dial_7_60782_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_107_2_dial_8_60782, face_107_2_dial_7_60782_group[(hour / 10) % 10]);
+        lv_image_set_src(face_107_2_dial_8_60782, face_107_2_dial_7_60782_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_107_2_dial_9_60782, face_107_2_dial_7_60782_group[(minute / 1) % 10]);
+        lv_image_set_src(face_107_2_dial_9_60782, face_107_2_dial_7_60782_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_107_2_dial_10_60782, face_107_2_dial_7_60782_group[(minute / 10) % 10]);
+        lv_image_set_src(face_107_2_dial_10_60782, face_107_2_dial_7_60782_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_107_2_dial_12_85153, face_107_2_dial_12_85153_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_107_2_dial_12_85153, face_107_2_dial_12_85153_group[((weekday + 6) / 1) % 7]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_month = month;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_107_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -322,8 +312,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_set_style_pad_top(face_107_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_107_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_107_2_dial_0_264 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_0_264, ZSW_LV_IMG_USE(face_107_2_dial_0_264_0));
+    face_107_2_dial_0_264 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_0_264, ZSW_LV_IMG_USE(face_107_2_dial_0_264_0));
     lv_obj_set_width(face_107_2_dial_0_264, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_0_264, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_0_264, 0);
@@ -331,8 +321,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_0_264, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_0_264, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_1_58372 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_1_58372, ZSW_LV_IMG_USE(face_107_2_dial_1_58372_0));
+    face_107_2_dial_1_58372 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_1_58372, ZSW_LV_IMG_USE(face_107_2_dial_1_58372_0));
     lv_obj_set_width(face_107_2_dial_1_58372, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_1_58372, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_1_58372, 88);
@@ -340,8 +330,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_1_58372, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_1_58372, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_2_58391 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_2_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
+    face_107_2_dial_2_58391 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_2_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
     lv_obj_set_width(face_107_2_dial_2_58391, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_2_58391, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_2_58391, 73);
@@ -349,8 +339,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_2_58391, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_2_58391, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_3_58391 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_3_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
+    face_107_2_dial_3_58391 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_3_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
     lv_obj_set_width(face_107_2_dial_3_58391, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_3_58391, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_3_58391, 61);
@@ -358,8 +348,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_3_58391, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_3_58391, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_4_58391 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_4_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
+    face_107_2_dial_4_58391 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_4_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
     lv_obj_set_width(face_107_2_dial_4_58391, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_4_58391, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_4_58391, 105);
@@ -367,8 +357,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_4_58391, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_4_58391, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_5_58391 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_5_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
+    face_107_2_dial_5_58391 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_5_58391, ZSW_LV_IMG_USE(face_107_2_dial_2_58391_0));
     lv_obj_set_width(face_107_2_dial_5_58391, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_5_58391, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_5_58391, 93);
@@ -376,8 +366,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_5_58391, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_5_58391, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_6_60345 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_6_60345, ZSW_LV_IMG_USE(face_107_2_dial_6_60345_0));
+    face_107_2_dial_6_60345 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_6_60345, ZSW_LV_IMG_USE(face_107_2_dial_6_60345_0));
     lv_obj_set_width(face_107_2_dial_6_60345, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_6_60345, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_6_60345, 116);
@@ -385,8 +375,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_6_60345, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_6_60345, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_7_60782 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_7_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
+    face_107_2_dial_7_60782 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_7_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
     lv_obj_set_width(face_107_2_dial_7_60782, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_7_60782, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_7_60782, 67);
@@ -394,8 +384,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_7_60782, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_7_60782, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_8_60782 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_8_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
+    face_107_2_dial_8_60782 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_8_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
     lv_obj_set_width(face_107_2_dial_8_60782, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_8_60782, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_8_60782, 22);
@@ -403,8 +393,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_8_60782, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_8_60782, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_9_60782 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_9_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
+    face_107_2_dial_9_60782 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_9_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
     lv_obj_set_width(face_107_2_dial_9_60782, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_9_60782, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_9_60782, 179);
@@ -412,8 +402,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_9_60782, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_9_60782, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_10_60782 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_10_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
+    face_107_2_dial_10_60782 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_10_60782, ZSW_LV_IMG_USE(face_107_2_dial_7_60782_0));
     lv_obj_set_width(face_107_2_dial_10_60782, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_10_60782, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_10_60782, 134);
@@ -421,8 +411,8 @@ void watchface_107_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_107_2_dial_10_60782, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_107_2_dial_10_60782, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_107_2_dial_12_85153 = lv_img_create(face_107_2_dial);
-    lv_img_set_src(face_107_2_dial_12_85153, ZSW_LV_IMG_USE(face_107_2_dial_12_85153_0));
+    face_107_2_dial_12_85153 = lv_image_create(face_107_2_dial);
+    lv_image_set_src(face_107_2_dial_12_85153, ZSW_LV_IMG_USE(face_107_2_dial_12_85153_0));
     lv_obj_set_width(face_107_2_dial_12_85153, LV_SIZE_CONTENT);
     lv_obj_set_height(face_107_2_dial_12_85153, LV_SIZE_CONTENT);
     lv_obj_set_x(face_107_2_dial_12_85153, 128);

--- a/app/src/ui/watchfaces/116_2_dial/zsw_watchface_116_2_dial_ui.c
+++ b/app/src/ui/watchfaces/116_2_dial/zsw_watchface_116_2_dial_ui.c
@@ -15,7 +15,6 @@
 
 LOG_MODULE_REGISTER(watchface_116_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_116_2_dial;
 static lv_obj_t *face_116_2_dial = NULL;
 static watchface_app_evt_listener ui_116_2_dial_evt_cb;
 
@@ -172,20 +171,15 @@ const void *face_116_2_dial_18_162424_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_116_2_dial_remove(void)
@@ -229,40 +223,37 @@ static void watchface_116_2_dial_set_datetime(int day_of_week, int date, int day
     month += 1;
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_116_2_dial_1_59716, face_116_2_dial_1_59716_group[(day / 1) % 10]);
+        lv_image_set_src(face_116_2_dial_1_59716, face_116_2_dial_1_59716_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_116_2_dial_2_59716, face_116_2_dial_1_59716_group[(day / 10) % 10]);
+        lv_image_set_src(face_116_2_dial_2_59716, face_116_2_dial_1_59716_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_116_2_dial_3_62316, face_116_2_dial_3_62316_group[(hour / 1) % 10]);
+        lv_image_set_src(face_116_2_dial_3_62316, face_116_2_dial_3_62316_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_116_2_dial_4_62316, face_116_2_dial_3_62316_group[(hour / 10) % 10]);
+        lv_image_set_src(face_116_2_dial_4_62316, face_116_2_dial_3_62316_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_116_2_dial_5_114030, face_116_2_dial_5_114030_group[(minute / 1) % 10]);
+        lv_image_set_src(face_116_2_dial_5_114030, face_116_2_dial_5_114030_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_116_2_dial_6_114030, face_116_2_dial_5_114030_group[(minute / 10) % 10]);
+        lv_image_set_src(face_116_2_dial_6_114030, face_116_2_dial_5_114030_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_116_2_dial_18_162424, face_116_2_dial_18_162424_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_116_2_dial_18_162424, face_116_2_dial_18_162424_group[((weekday + 6) / 1) % 7]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_116_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -287,7 +278,7 @@ static void watchface_116_2_dial_set_weather(int8_t temp, int icon)
         return;
     }
 
-    lv_img_set_src(face_116_2_dial_8_58492, face_116_2_dial_weather[icon % 8]);
+    lv_image_set_src(face_116_2_dial_8_58492, face_116_2_dial_weather[icon % 8]);
 
 }
 
@@ -347,8 +338,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_set_style_pad_top(face_116_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_116_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_116_2_dial_0_384 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_0_384, ZSW_LV_IMG_USE(face_116_2_dial_0_384_0));
+    face_116_2_dial_0_384 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_0_384, ZSW_LV_IMG_USE(face_116_2_dial_0_384_0));
     lv_obj_set_width(face_116_2_dial_0_384, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_0_384, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_0_384, 0);
@@ -356,8 +347,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_0_384, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_0_384, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_1_59716 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_1_59716, ZSW_LV_IMG_USE(face_116_2_dial_1_59716_0));
+    face_116_2_dial_1_59716 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_1_59716, ZSW_LV_IMG_USE(face_116_2_dial_1_59716_0));
     lv_obj_set_width(face_116_2_dial_1_59716, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_1_59716, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_1_59716, 59);
@@ -365,8 +356,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_1_59716, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_1_59716, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_2_59716 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_2_59716, ZSW_LV_IMG_USE(face_116_2_dial_1_59716_0));
+    face_116_2_dial_2_59716 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_2_59716, ZSW_LV_IMG_USE(face_116_2_dial_1_59716_0));
     lv_obj_set_width(face_116_2_dial_2_59716, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_2_59716, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_2_59716, 49);
@@ -374,8 +365,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_2_59716, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_2_59716, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_3_62316 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_3_62316, ZSW_LV_IMG_USE(face_116_2_dial_3_62316_0));
+    face_116_2_dial_3_62316 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_3_62316, ZSW_LV_IMG_USE(face_116_2_dial_3_62316_0));
     lv_obj_set_width(face_116_2_dial_3_62316, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_3_62316, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_3_62316, 144);
@@ -383,8 +374,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_3_62316, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_3_62316, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_4_62316 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_4_62316, ZSW_LV_IMG_USE(face_116_2_dial_3_62316_0));
+    face_116_2_dial_4_62316 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_4_62316, ZSW_LV_IMG_USE(face_116_2_dial_3_62316_0));
     lv_obj_set_width(face_116_2_dial_4_62316, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_4_62316, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_4_62316, 87);
@@ -392,8 +383,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_4_62316, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_4_62316, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_5_114030 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_5_114030, ZSW_LV_IMG_USE(face_116_2_dial_5_114030_0));
+    face_116_2_dial_5_114030 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_5_114030, ZSW_LV_IMG_USE(face_116_2_dial_5_114030_0));
     lv_obj_set_width(face_116_2_dial_5_114030, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_5_114030, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_5_114030, 169);
@@ -401,8 +392,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_5_114030, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_5_114030, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_6_114030 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_6_114030, ZSW_LV_IMG_USE(face_116_2_dial_5_114030_0));
+    face_116_2_dial_6_114030 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_6_114030, ZSW_LV_IMG_USE(face_116_2_dial_5_114030_0));
     lv_obj_set_width(face_116_2_dial_6_114030, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_6_114030, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_6_114030, 112);
@@ -410,8 +401,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_6_114030, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_6_114030, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_8_58492 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_8_58492, ZSW_LV_IMG_USE(face_116_2_dial_8_58492_0));
+    face_116_2_dial_8_58492 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_8_58492, ZSW_LV_IMG_USE(face_116_2_dial_8_58492_0));
     lv_obj_set_width(face_116_2_dial_8_58492, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_8_58492, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_8_58492, 41);
@@ -419,8 +410,8 @@ void watchface_116_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_
     lv_obj_add_flag(face_116_2_dial_8_58492, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_116_2_dial_8_58492, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_116_2_dial_18_162424 = lv_img_create(face_116_2_dial);
-    lv_img_set_src(face_116_2_dial_18_162424, ZSW_LV_IMG_USE(face_116_2_dial_18_162424_0));
+    face_116_2_dial_18_162424 = lv_image_create(face_116_2_dial);
+    lv_image_set_src(face_116_2_dial_18_162424, ZSW_LV_IMG_USE(face_116_2_dial_18_162424_0));
     lv_obj_set_width(face_116_2_dial_18_162424, LV_SIZE_CONTENT);
     lv_obj_set_height(face_116_2_dial_18_162424, LV_SIZE_CONTENT);
     lv_obj_set_x(face_116_2_dial_18_162424, 43);

--- a/app/src/ui/watchfaces/66_2_dial/zsw_watchface_66_2_dial_ui.c
+++ b/app/src/ui/watchfaces/66_2_dial/zsw_watchface_66_2_dial_ui.c
@@ -16,7 +16,6 @@
 
 LOG_MODULE_REGISTER(watchface_66_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_66_2_dial;
 static lv_obj_t *face_66_2_dial = NULL;
 static watchface_app_evt_listener ui_66_2_dial_evt_cb;
 static zsw_ui_notification_area_t *zsw_ui_notifications_area;
@@ -205,20 +204,15 @@ const void *face_66_2_dial_8_123132_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_66_2_dial_remove(void)
@@ -262,40 +256,37 @@ static void watchface_66_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_66_2_dial_1_68896, face_66_2_dial_1_68896_group[(hour / 1) % 10]);
+        lv_image_set_src(face_66_2_dial_1_68896, face_66_2_dial_1_68896_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_66_2_dial_2_61582, face_66_2_dial_2_61582_group[(hour / 10) % 3]);
+        lv_image_set_src(face_66_2_dial_2_61582, face_66_2_dial_2_61582_group[(hour / 10) % 3]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_66_2_dial_3_105480, face_66_2_dial_3_105480_group[(minute / 1) % 10]);
+        lv_image_set_src(face_66_2_dial_3_105480, face_66_2_dial_3_105480_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_66_2_dial_4_92084, face_66_2_dial_4_92084_group[(minute / 10) % 10]);
+        lv_image_set_src(face_66_2_dial_4_92084, face_66_2_dial_4_92084_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_66_2_dial_5_60018, face_66_2_dial_5_60018_group[(day / 1) % 10]);
+        lv_image_set_src(face_66_2_dial_5_60018, face_66_2_dial_5_60018_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_66_2_dial_6_58294, face_66_2_dial_6_58294_group[(day / 10) % 10]);
+        lv_image_set_src(face_66_2_dial_6_58294, face_66_2_dial_6_58294_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_66_2_dial_8_123132, face_66_2_dial_8_123132_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_66_2_dial_8_123132, face_66_2_dial_8_123132_group[((weekday + 6) / 1) % 7]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_66_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -379,8 +370,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_66_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_66_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_66_2_dial_0_184 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_0_184, ZSW_LV_IMG_USE(face_66_2_dial_0_184_0));
+    face_66_2_dial_0_184 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_0_184, ZSW_LV_IMG_USE(face_66_2_dial_0_184_0));
     lv_obj_set_width(face_66_2_dial_0_184, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_0_184, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_0_184, 0);
@@ -388,8 +379,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_0_184, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_0_184, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_1_68896 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_1_68896, ZSW_LV_IMG_USE(face_66_2_dial_1_68896_0));
+    face_66_2_dial_1_68896 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_1_68896, ZSW_LV_IMG_USE(face_66_2_dial_1_68896_0));
     lv_obj_set_width(face_66_2_dial_1_68896, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_1_68896, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_1_68896, 134);
@@ -397,8 +388,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_1_68896, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_1_68896, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_2_61582 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_2_61582, ZSW_LV_IMG_USE(face_66_2_dial_2_61582_0));
+    face_66_2_dial_2_61582 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_2_61582, ZSW_LV_IMG_USE(face_66_2_dial_2_61582_0));
     lv_obj_set_width(face_66_2_dial_2_61582, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_2_61582, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_2_61582, 83);
@@ -406,8 +397,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_2_61582, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_2_61582, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_3_105480 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_3_105480, ZSW_LV_IMG_USE(face_66_2_dial_3_105480_0));
+    face_66_2_dial_3_105480 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_3_105480, ZSW_LV_IMG_USE(face_66_2_dial_3_105480_0));
     lv_obj_set_width(face_66_2_dial_3_105480, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_3_105480, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_3_105480, 165);
@@ -415,8 +406,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_3_105480, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_3_105480, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_4_92084 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_4_92084, ZSW_LV_IMG_USE(face_66_2_dial_4_92084_0));
+    face_66_2_dial_4_92084 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_4_92084, ZSW_LV_IMG_USE(face_66_2_dial_4_92084_0));
     lv_obj_set_width(face_66_2_dial_4_92084, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_4_92084, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_4_92084, 125);
@@ -424,8 +415,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_4_92084, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_4_92084, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_5_60018 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_5_60018, ZSW_LV_IMG_USE(face_66_2_dial_5_60018_0));
+    face_66_2_dial_5_60018 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_5_60018, ZSW_LV_IMG_USE(face_66_2_dial_5_60018_0));
     lv_obj_set_width(face_66_2_dial_5_60018, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_5_60018, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_5_60018, 106);
@@ -433,8 +424,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_5_60018, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_5_60018, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_6_58294 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_6_58294, ZSW_LV_IMG_USE(face_66_2_dial_6_58294_0));
+    face_66_2_dial_6_58294 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_6_58294, ZSW_LV_IMG_USE(face_66_2_dial_6_58294_0));
     lv_obj_set_width(face_66_2_dial_6_58294, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_6_58294, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_6_58294, 94);
@@ -442,8 +433,8 @@ void watchface_66_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_66_2_dial_6_58294, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_66_2_dial_6_58294, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_66_2_dial_8_123132 = lv_img_create(face_66_2_dial);
-    lv_img_set_src(face_66_2_dial_8_123132, ZSW_LV_IMG_USE(face_66_2_dial_8_123132_0));
+    face_66_2_dial_8_123132 = lv_image_create(face_66_2_dial);
+    lv_image_set_src(face_66_2_dial_8_123132, ZSW_LV_IMG_USE(face_66_2_dial_8_123132_0));
     lv_obj_set_width(face_66_2_dial_8_123132, LV_SIZE_CONTENT);
     lv_obj_set_height(face_66_2_dial_8_123132, LV_SIZE_CONTENT);
     lv_obj_set_x(face_66_2_dial_8_123132, 83);

--- a/app/src/ui/watchfaces/70_2_dial/zsw_watchface_70_2_dial_ui.c
+++ b/app/src/ui/watchfaces/70_2_dial/zsw_watchface_70_2_dial_ui.c
@@ -15,7 +15,6 @@
 
 LOG_MODULE_REGISTER(watchface_70_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_70_2_dial;
 static lv_obj_t *face_70_2_dial = NULL;
 static watchface_app_evt_listener ui_70_2_dial_evt_cb;
 
@@ -108,20 +107,15 @@ const void *face_70_2_dial_5_59328_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_70_2_dial_remove(void)
@@ -165,28 +159,26 @@ static void watchface_70_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_70_2_dial_1_125929, face_70_2_dial_1_125929_group[(hour / 1) % 10]);
+        lv_image_set_src(face_70_2_dial_1_125929, face_70_2_dial_1_125929_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_70_2_dial_2_125929, face_70_2_dial_1_125929_group[(hour / 10) % 10]);
+        lv_image_set_src(face_70_2_dial_2_125929, face_70_2_dial_1_125929_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_70_2_dial_3_125929, face_70_2_dial_1_125929_group[(minute / 1) % 10]);
+        lv_image_set_src(face_70_2_dial_3_125929, face_70_2_dial_1_125929_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_70_2_dial_4_125929, face_70_2_dial_1_125929_group[(minute / 10) % 10]);
+        lv_image_set_src(face_70_2_dial_4_125929, face_70_2_dial_1_125929_group[(minute / 10) % 10]);
     }
-    lv_img_set_angle(face_70_2_dial_13_60900, hour * 300 + (minute * 5));
-    lv_img_set_angle(face_70_2_dial_29_90967, minute * 60);
-    lv_img_set_angle(face_70_2_dial_45_130547, second * 60);
+    lv_image_set_rotation(face_70_2_dial_13_60900, hour * 300 + (minute * 5));
+    lv_image_set_rotation(face_70_2_dial_29_90967, minute * 60);
+    lv_image_set_rotation(face_70_2_dial_45_130547, second * 60);
 
+    last_hour = hour;
+    last_minute = minute;
 }
 
 static void watchface_70_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -196,30 +188,26 @@ static void watchface_70_2_dial_set_step(int32_t steps, int32_t distance, int32_
     }
 
     if (getPlaceValue(last_steps, 1) != getPlaceValue(steps, 1)) {
-        last_steps = setPlaceValue(last_steps, 1, getPlaceValue(steps, 1));
-        lv_img_set_src(face_70_2_dial_8_59328, face_70_2_dial_5_59328_group[(steps / 1) % 10]);
+        lv_image_set_src(face_70_2_dial_8_59328, face_70_2_dial_5_59328_group[(steps / 1) % 10]);
     }
 
     if (getPlaceValue(last_steps, 2) != getPlaceValue(steps, 2)) {
-        last_steps = setPlaceValue(last_steps, 2, getPlaceValue(steps, 2));
-        lv_img_set_src(face_70_2_dial_9_59328, face_70_2_dial_5_59328_group[(steps / 10) % 10]);
+        lv_image_set_src(face_70_2_dial_9_59328, face_70_2_dial_5_59328_group[(steps / 10) % 10]);
     }
 
     if (getPlaceValue(last_steps, 3) != getPlaceValue(steps, 3)) {
-        last_steps = setPlaceValue(last_steps, 3, getPlaceValue(steps, 3));
-        lv_img_set_src(face_70_2_dial_10_59328, face_70_2_dial_5_59328_group[(steps / 100) % 10]);
+        lv_image_set_src(face_70_2_dial_10_59328, face_70_2_dial_5_59328_group[(steps / 100) % 10]);
     }
 
     if (getPlaceValue(last_steps, 4) != getPlaceValue(steps, 4)) {
-        last_steps = setPlaceValue(last_steps, 4, getPlaceValue(steps, 4));
-        lv_img_set_src(face_70_2_dial_11_59328, face_70_2_dial_5_59328_group[(steps / 1000) % 10]);
+        lv_image_set_src(face_70_2_dial_11_59328, face_70_2_dial_5_59328_group[(steps / 1000) % 10]);
     }
 
     if (getPlaceValue(last_steps, 5) != getPlaceValue(steps, 5)) {
-        last_steps = setPlaceValue(last_steps, 5, getPlaceValue(steps, 5));
-        lv_img_set_src(face_70_2_dial_12_59328, face_70_2_dial_5_59328_group[(steps / 10000) % 10]);
+        lv_image_set_src(face_70_2_dial_12_59328, face_70_2_dial_5_59328_group[(steps / 10000) % 10]);
     }
 
+    last_steps = steps;
 }
 
 static void watchface_70_2_dial_set_hrm(int32_t bpm, int32_t oxygen)
@@ -228,9 +216,9 @@ static void watchface_70_2_dial_set_hrm(int32_t bpm, int32_t oxygen)
         return;
     }
 
-    lv_img_set_src(face_70_2_dial_5_59328, face_70_2_dial_5_59328_group[(bpm / 1) % 10]);
-    lv_img_set_src(face_70_2_dial_6_59328, face_70_2_dial_5_59328_group[(bpm / 10) % 10]);
-    lv_img_set_src(face_70_2_dial_7_59328, face_70_2_dial_5_59328_group[(bpm / 100) % 10]);
+    lv_image_set_src(face_70_2_dial_5_59328, face_70_2_dial_5_59328_group[(bpm / 1) % 10]);
+    lv_image_set_src(face_70_2_dial_6_59328, face_70_2_dial_5_59328_group[(bpm / 10) % 10]);
+    lv_image_set_src(face_70_2_dial_7_59328, face_70_2_dial_5_59328_group[(bpm / 100) % 10]);
 
 }
 
@@ -297,8 +285,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_70_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_70_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_70_2_dial_0_1224 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_0_1224, ZSW_LV_IMG_USE(face_70_2_dial_0_1224_0));
+    face_70_2_dial_0_1224 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_0_1224, ZSW_LV_IMG_USE(face_70_2_dial_0_1224_0));
     lv_obj_set_width(face_70_2_dial_0_1224, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_0_1224, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_0_1224, 0);
@@ -306,8 +294,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_0_1224, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_0_1224, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_1_125929 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_1_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
+    face_70_2_dial_1_125929 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_1_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
     lv_obj_set_width(face_70_2_dial_1_125929, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_1_125929, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_1_125929, 205);
@@ -315,8 +303,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_1_125929, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_1_125929, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_2_125929 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_2_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
+    face_70_2_dial_2_125929 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_2_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
     lv_obj_set_width(face_70_2_dial_2_125929, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_2_125929, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_2_125929, 182);
@@ -324,8 +312,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_2_125929, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_2_125929, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_3_125929 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_3_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
+    face_70_2_dial_3_125929 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_3_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
     lv_obj_set_width(face_70_2_dial_3_125929, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_3_125929, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_3_125929, 205);
@@ -333,8 +321,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_3_125929, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_3_125929, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_4_125929 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_4_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
+    face_70_2_dial_4_125929 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_4_125929, ZSW_LV_IMG_USE(face_70_2_dial_1_125929_0));
     lv_obj_set_width(face_70_2_dial_4_125929, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_4_125929, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_4_125929, 182);
@@ -342,8 +330,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_4_125929, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_4_125929, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_5_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_5_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_5_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_5_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_5_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_5_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_5_59328, 43);
@@ -351,8 +339,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_5_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_5_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_6_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_6_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_6_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_6_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_6_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_6_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_6_59328, 32);
@@ -360,8 +348,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_6_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_6_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_7_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_7_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_7_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_7_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_7_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_7_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_7_59328, 21);
@@ -369,8 +357,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_7_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_7_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_8_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_8_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_8_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_8_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_8_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_8_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_8_59328, 55);
@@ -378,8 +366,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_8_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_8_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_9_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_9_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_9_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_9_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_9_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_9_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_9_59328, 44);
@@ -387,8 +375,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_9_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_9_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_10_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_10_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_10_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_10_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_10_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_10_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_10_59328, 33);
@@ -396,8 +384,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_10_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_10_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_11_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_11_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_11_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_11_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_11_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_11_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_11_59328, 22);
@@ -405,8 +393,8 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_11_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_11_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_12_59328 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_12_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
+    face_70_2_dial_12_59328 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_12_59328, ZSW_LV_IMG_USE(face_70_2_dial_5_59328_0));
     lv_obj_set_width(face_70_2_dial_12_59328, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_12_59328, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_12_59328, 11);
@@ -414,35 +402,35 @@ void watchface_70_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_70_2_dial_12_59328, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_12_59328, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_70_2_dial_13_60900 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_13_60900, ZSW_LV_IMG_USE(face_70_2_dial_13_60900_0));
+    face_70_2_dial_13_60900 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_13_60900, ZSW_LV_IMG_USE(face_70_2_dial_13_60900_0));
     lv_obj_set_width(face_70_2_dial_13_60900, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_13_60900, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_13_60900, 110);
     lv_obj_set_y(face_70_2_dial_13_60900, 9);
     lv_obj_add_flag(face_70_2_dial_13_60900, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_13_60900, LV_OBJ_FLAG_SCROLLABLE);
-    lv_img_set_pivot(face_70_2_dial_13_60900, 10, 51);
+    lv_image_set_pivot(face_70_2_dial_13_60900, 10, 51);
 
-    face_70_2_dial_29_90967 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_29_90967, ZSW_LV_IMG_USE(face_70_2_dial_29_90967_0));
+    face_70_2_dial_29_90967 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_29_90967, ZSW_LV_IMG_USE(face_70_2_dial_29_90967_0));
     lv_obj_set_width(face_70_2_dial_29_90967, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_29_90967, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_29_90967, 111);
     lv_obj_set_y(face_70_2_dial_29_90967, 121);
     lv_obj_add_flag(face_70_2_dial_29_90967, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_29_90967, LV_OBJ_FLAG_SCROLLABLE);
-    lv_img_set_pivot(face_70_2_dial_29_90967, 9, 59);
+    lv_image_set_pivot(face_70_2_dial_29_90967, 9, 59);
 
-    face_70_2_dial_45_130547 = lv_img_create(face_70_2_dial);
-    lv_img_set_src(face_70_2_dial_45_130547, ZSW_LV_IMG_USE(face_70_2_dial_45_130547_0));
+    face_70_2_dial_45_130547 = lv_image_create(face_70_2_dial);
+    lv_image_set_src(face_70_2_dial_45_130547, ZSW_LV_IMG_USE(face_70_2_dial_45_130547_0));
     lv_obj_set_width(face_70_2_dial_45_130547, LV_SIZE_CONTENT);
     lv_obj_set_height(face_70_2_dial_45_130547, LV_SIZE_CONTENT);
     lv_obj_set_x(face_70_2_dial_45_130547, 118);
     lv_obj_set_y(face_70_2_dial_45_130547, 112);
     lv_obj_add_flag(face_70_2_dial_45_130547, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_70_2_dial_45_130547, LV_OBJ_FLAG_SCROLLABLE);
-    lv_img_set_pivot(face_70_2_dial_45_130547, 2, 8);
+    lv_image_set_pivot(face_70_2_dial_45_130547, 2, 8);
 
 }
 

--- a/app/src/ui/watchfaces/73_2_dial/zsw_watchface_73_2_dial_ui.c
+++ b/app/src/ui/watchfaces/73_2_dial/zsw_watchface_73_2_dial_ui.c
@@ -15,7 +15,6 @@
 
 LOG_MODULE_REGISTER(watchface_73_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_73_2_dial;
 static lv_obj_t *face_73_2_dial = NULL;
 static watchface_app_evt_listener ui_73_2_dial_evt_cb;
 
@@ -235,20 +234,15 @@ const void *face_73_2_dial_27_127086_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_73_2_dial_remove(void)
@@ -292,70 +286,63 @@ static void watchface_73_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_year, 1) != getPlaceValue(year, 1)) {
-        last_year = setPlaceValue(last_year, 1, getPlaceValue(year, 1));
-        lv_img_set_src(face_73_2_dial_8_59942, face_73_2_dial_8_59942_group[(year / 1) % 10]);
+        lv_image_set_src(face_73_2_dial_8_59942, face_73_2_dial_8_59942_group[(year / 1) % 10]);
     }
 
     if (getPlaceValue(last_year, 2) != getPlaceValue(year, 2)) {
-        last_year = setPlaceValue(last_year, 2, getPlaceValue(year, 2));
-        lv_img_set_src(face_73_2_dial_9_59942, face_73_2_dial_8_59942_group[(year / 10) % 10]);
+        lv_image_set_src(face_73_2_dial_9_59942, face_73_2_dial_8_59942_group[(year / 10) % 10]);
     }
 
     if (getPlaceValue(last_year, 3) != getPlaceValue(year, 3)) {
-        last_year = setPlaceValue(last_year, 3, getPlaceValue(year, 3));
-        lv_img_set_src(face_73_2_dial_10_59942, face_73_2_dial_8_59942_group[(year / 100) % 10]);
+        lv_image_set_src(face_73_2_dial_10_59942, face_73_2_dial_8_59942_group[(year / 100) % 10]);
     }
 
     if (getPlaceValue(last_year, 4) != getPlaceValue(year, 4)) {
-        last_year = setPlaceValue(last_year, 4, getPlaceValue(year, 4));
-        lv_img_set_src(face_73_2_dial_11_59942, face_73_2_dial_8_59942_group[(year / 1000) % 10]);
+        lv_image_set_src(face_73_2_dial_11_59942, face_73_2_dial_8_59942_group[(year / 1000) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        last_month = setPlaceValue(last_month, 1, getPlaceValue(month, 1));
-        lv_img_set_src(face_73_2_dial_13_59942, face_73_2_dial_8_59942_group[(month / 1) % 10]);
+        lv_image_set_src(face_73_2_dial_13_59942, face_73_2_dial_8_59942_group[(month / 1) % 10]);
     }
 
     if (getPlaceValue(last_month, 2) != getPlaceValue(month, 2)) {
-        last_month = setPlaceValue(last_month, 2, getPlaceValue(month, 2));
-        lv_img_set_src(face_73_2_dial_14_59942, face_73_2_dial_8_59942_group[(month / 10) % 10]);
+        lv_image_set_src(face_73_2_dial_14_59942, face_73_2_dial_8_59942_group[(month / 10) % 10]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_73_2_dial_15_59942, face_73_2_dial_8_59942_group[(day / 1) % 10]);
+        lv_image_set_src(face_73_2_dial_15_59942, face_73_2_dial_8_59942_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_73_2_dial_16_59942, face_73_2_dial_8_59942_group[(day / 10) % 10]);
+        lv_image_set_src(face_73_2_dial_16_59942, face_73_2_dial_8_59942_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_73_2_dial_22_112986, face_73_2_dial_22_112986_group[(hour / 1) % 10]);
+        lv_image_set_src(face_73_2_dial_22_112986, face_73_2_dial_22_112986_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_73_2_dial_23_112986, face_73_2_dial_22_112986_group[(hour / 10) % 10]);
+        lv_image_set_src(face_73_2_dial_23_112986, face_73_2_dial_22_112986_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_73_2_dial_24_112986, face_73_2_dial_22_112986_group[(minute / 1) % 10]);
+        lv_image_set_src(face_73_2_dial_24_112986, face_73_2_dial_22_112986_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_73_2_dial_25_112986, face_73_2_dial_22_112986_group[(minute / 10) % 10]);
+        lv_image_set_src(face_73_2_dial_25_112986, face_73_2_dial_22_112986_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_73_2_dial_27_127086, face_73_2_dial_27_127086_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_73_2_dial_27_127086, face_73_2_dial_27_127086_group[((weekday + 6) / 1) % 7]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_year = year;
+    last_month = month;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_73_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -365,30 +352,26 @@ static void watchface_73_2_dial_set_step(int32_t steps, int32_t distance, int32_
     }
 
     if (getPlaceValue(last_steps, 1) != getPlaceValue(steps, 1)) {
-        last_steps = setPlaceValue(last_steps, 1, getPlaceValue(steps, 1));
-        lv_img_set_src(face_73_2_dial_17_110874, face_73_2_dial_17_110874_group[(steps / 1) % 10]);
+        lv_image_set_src(face_73_2_dial_17_110874, face_73_2_dial_17_110874_group[(steps / 1) % 10]);
     }
 
     if (getPlaceValue(last_steps, 2) != getPlaceValue(steps, 2)) {
-        last_steps = setPlaceValue(last_steps, 2, getPlaceValue(steps, 2));
-        lv_img_set_src(face_73_2_dial_18_110874, face_73_2_dial_17_110874_group[(steps / 10) % 10]);
+        lv_image_set_src(face_73_2_dial_18_110874, face_73_2_dial_17_110874_group[(steps / 10) % 10]);
     }
 
     if (getPlaceValue(last_steps, 3) != getPlaceValue(steps, 3)) {
-        last_steps = setPlaceValue(last_steps, 3, getPlaceValue(steps, 3));
-        lv_img_set_src(face_73_2_dial_19_110874, face_73_2_dial_17_110874_group[(steps / 100) % 10]);
+        lv_image_set_src(face_73_2_dial_19_110874, face_73_2_dial_17_110874_group[(steps / 100) % 10]);
     }
 
     if (getPlaceValue(last_steps, 4) != getPlaceValue(steps, 4)) {
-        last_steps = setPlaceValue(last_steps, 4, getPlaceValue(steps, 4));
-        lv_img_set_src(face_73_2_dial_20_110874, face_73_2_dial_17_110874_group[(steps / 1000) % 10]);
+        lv_image_set_src(face_73_2_dial_20_110874, face_73_2_dial_17_110874_group[(steps / 1000) % 10]);
     }
 
     if (getPlaceValue(last_steps, 5) != getPlaceValue(steps, 5)) {
-        last_steps = setPlaceValue(last_steps, 5, getPlaceValue(steps, 5));
-        lv_img_set_src(face_73_2_dial_21_110874, face_73_2_dial_17_110874_group[(steps / 10000) % 10]);
+        lv_image_set_src(face_73_2_dial_21_110874, face_73_2_dial_17_110874_group[(steps / 10000) % 10]);
     }
 
+    last_steps = steps;
 }
 
 static void watchface_73_2_dial_set_hrm(int32_t bpm, int32_t oxygen)
@@ -462,8 +445,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_73_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_73_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_73_2_dial_0_1816 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_0_1816, ZSW_LV_IMG_USE(face_73_2_dial_0_1816_0));
+    face_73_2_dial_0_1816 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_0_1816, ZSW_LV_IMG_USE(face_73_2_dial_0_1816_0));
     lv_obj_set_width(face_73_2_dial_0_1816, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_0_1816, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_0_1816, 0);
@@ -471,8 +454,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_0_1816, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_0_1816, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_1_61342 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_1_61342, ZSW_LV_IMG_USE(face_73_2_dial_1_61342_0));
+    face_73_2_dial_1_61342 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_1_61342, ZSW_LV_IMG_USE(face_73_2_dial_1_61342_0));
     lv_obj_set_width(face_73_2_dial_1_61342, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_1_61342, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_1_61342, 202);
@@ -480,8 +463,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_1_61342, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_1_61342, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_2_85528 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_2_85528, ZSW_LV_IMG_USE(face_73_2_dial_2_85528_0));
+    face_73_2_dial_2_85528 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_2_85528, ZSW_LV_IMG_USE(face_73_2_dial_2_85528_0));
     lv_obj_set_width(face_73_2_dial_2_85528, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_2_85528, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_2_85528, 14);
@@ -489,8 +472,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_2_85528, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_2_85528, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_7_59924 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_7_59924, ZSW_LV_IMG_USE(face_73_2_dial_7_59924_0));
+    face_73_2_dial_7_59924 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_7_59924, ZSW_LV_IMG_USE(face_73_2_dial_7_59924_0));
     lv_obj_set_width(face_73_2_dial_7_59924, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_7_59924, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_7_59924, 117);
@@ -498,8 +481,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_7_59924, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_7_59924, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_8_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_8_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_8_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_8_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_8_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_8_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_8_59942, 107);
@@ -507,8 +490,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_8_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_8_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_9_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_9_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_9_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_9_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_9_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_9_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_9_59942, 98);
@@ -516,8 +499,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_9_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_9_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_10_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_10_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_10_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_10_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_10_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_10_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_10_59942, 89);
@@ -525,8 +508,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_10_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_10_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_11_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_11_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_11_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_11_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_11_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_11_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_11_59942, 80);
@@ -534,8 +517,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_11_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_11_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_12_59924 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_12_59924, ZSW_LV_IMG_USE(face_73_2_dial_7_59924_0));
+    face_73_2_dial_12_59924 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_12_59924, ZSW_LV_IMG_USE(face_73_2_dial_7_59924_0));
     lv_obj_set_width(face_73_2_dial_12_59924, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_12_59924, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_12_59924, 142);
@@ -543,8 +526,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_12_59924, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_12_59924, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_13_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_13_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_13_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_13_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_13_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_13_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_13_59942, 132);
@@ -552,8 +535,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_13_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_13_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_14_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_14_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_14_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_14_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_14_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_14_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_14_59942, 123);
@@ -561,8 +544,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_14_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_14_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_15_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_15_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_15_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_15_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_15_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_15_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_15_59942, 157);
@@ -570,8 +553,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_15_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_15_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_16_59942 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_16_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
+    face_73_2_dial_16_59942 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_16_59942, ZSW_LV_IMG_USE(face_73_2_dial_8_59942_0));
     lv_obj_set_width(face_73_2_dial_16_59942, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_16_59942, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_16_59942, 148);
@@ -579,8 +562,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_16_59942, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_16_59942, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_17_110874 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_17_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
+    face_73_2_dial_17_110874 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_17_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
     lv_obj_set_width(face_73_2_dial_17_110874, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_17_110874, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_17_110874, 149);
@@ -588,8 +571,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_17_110874, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_17_110874, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_18_110874 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_18_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
+    face_73_2_dial_18_110874 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_18_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
     lv_obj_set_width(face_73_2_dial_18_110874, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_18_110874, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_18_110874, 138);
@@ -597,8 +580,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_18_110874, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_18_110874, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_19_110874 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_19_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
+    face_73_2_dial_19_110874 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_19_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
     lv_obj_set_width(face_73_2_dial_19_110874, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_19_110874, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_19_110874, 127);
@@ -606,8 +589,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_19_110874, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_19_110874, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_20_110874 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_20_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
+    face_73_2_dial_20_110874 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_20_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
     lv_obj_set_width(face_73_2_dial_20_110874, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_20_110874, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_20_110874, 116);
@@ -615,8 +598,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_20_110874, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_20_110874, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_21_110874 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_21_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
+    face_73_2_dial_21_110874 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_21_110874, ZSW_LV_IMG_USE(face_73_2_dial_17_110874_0));
     lv_obj_set_width(face_73_2_dial_21_110874, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_21_110874, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_21_110874, 105);
@@ -624,8 +607,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_21_110874, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_21_110874, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_22_112986 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_22_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
+    face_73_2_dial_22_112986 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_22_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
     lv_obj_set_width(face_73_2_dial_22_112986, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_22_112986, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_22_112986, 89);
@@ -633,8 +616,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_22_112986, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_22_112986, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_23_112986 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_23_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
+    face_73_2_dial_23_112986 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_23_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
     lv_obj_set_width(face_73_2_dial_23_112986, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_23_112986, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_23_112986, 62);
@@ -642,8 +625,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_23_112986, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_23_112986, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_24_112986 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_24_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
+    face_73_2_dial_24_112986 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_24_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
     lv_obj_set_width(face_73_2_dial_24_112986, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_24_112986, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_24_112986, 154);
@@ -651,8 +634,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_24_112986, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_24_112986, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_25_112986 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_25_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
+    face_73_2_dial_25_112986 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_25_112986, ZSW_LV_IMG_USE(face_73_2_dial_22_112986_0));
     lv_obj_set_width(face_73_2_dial_25_112986, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_25_112986, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_25_112986, 127);
@@ -660,8 +643,8 @@ void watchface_73_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_73_2_dial_25_112986, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_73_2_dial_25_112986, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_73_2_dial_27_127086 = lv_img_create(face_73_2_dial);
-    lv_img_set_src(face_73_2_dial_27_127086, ZSW_LV_IMG_USE(face_73_2_dial_27_127086_0));
+    face_73_2_dial_27_127086 = lv_image_create(face_73_2_dial);
+    lv_image_set_src(face_73_2_dial_27_127086, ZSW_LV_IMG_USE(face_73_2_dial_27_127086_0));
     lv_obj_set_width(face_73_2_dial_27_127086, LV_SIZE_CONTENT);
     lv_obj_set_height(face_73_2_dial_27_127086, LV_SIZE_CONTENT);
     lv_obj_set_x(face_73_2_dial_27_127086, 87);

--- a/app/src/ui/watchfaces/75_2_dial/zsw_watchface_75_2_dial_ui.c
+++ b/app/src/ui/watchfaces/75_2_dial/zsw_watchface_75_2_dial_ui.c
@@ -16,7 +16,6 @@
 
 LOG_MODULE_REGISTER(watchface_75_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_75_2_dial;
 static lv_obj_t *face_75_2_dial = NULL;
 static watchface_app_evt_listener ui_75_2_dial_evt_cb;
 static zsw_ui_notification_area_t *zsw_ui_notifications_area;
@@ -87,20 +86,15 @@ const void *face_75_2_dial_2_216824_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_75_2_dial_remove(void)
@@ -141,13 +135,13 @@ static void watchface_75_2_dial_set_datetime(int day_of_week, int date, int day,
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_75_2_dial_2_216824, face_75_2_dial_2_216824_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_75_2_dial_2_216824, face_75_2_dial_2_216824_group[((weekday + 6) / 1) % 7]);
     }
-    lv_img_set_angle(face_75_2_dial_3_59132, hour * 300 + (minute * 5));
-    lv_img_set_angle(face_75_2_dial_19_89191, minute * 60);
-    lv_img_set_angle(face_75_2_dial_35_138999, second * 60);
+    lv_image_set_rotation(face_75_2_dial_3_59132, hour * 300 + (minute * 5));
+    lv_image_set_rotation(face_75_2_dial_19_89191, minute * 60);
+    lv_image_set_rotation(face_75_2_dial_35_138999, second * 60);
 
+    last_weekday = weekday;
 }
 
 static void watchface_75_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -231,8 +225,8 @@ void watchface_75_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_75_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_75_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_75_2_dial_0_1024 = lv_img_create(face_75_2_dial);
-    lv_img_set_src(face_75_2_dial_0_1024, ZSW_LV_IMG_USE(face_75_2_dial_0_1024_0));
+    face_75_2_dial_0_1024 = lv_image_create(face_75_2_dial);
+    lv_image_set_src(face_75_2_dial_0_1024, ZSW_LV_IMG_USE(face_75_2_dial_0_1024_0));
     lv_obj_set_width(face_75_2_dial_0_1024, LV_SIZE_CONTENT);
     lv_obj_set_height(face_75_2_dial_0_1024, LV_SIZE_CONTENT);
     lv_obj_set_x(face_75_2_dial_0_1024, 0);
@@ -240,8 +234,8 @@ void watchface_75_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_75_2_dial_0_1024, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_75_2_dial_0_1024, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_75_2_dial_2_216824 = lv_img_create(face_75_2_dial);
-    lv_img_set_src(face_75_2_dial_2_216824, ZSW_LV_IMG_USE(face_75_2_dial_2_216824_0));
+    face_75_2_dial_2_216824 = lv_image_create(face_75_2_dial);
+    lv_image_set_src(face_75_2_dial_2_216824, ZSW_LV_IMG_USE(face_75_2_dial_2_216824_0));
     lv_obj_set_width(face_75_2_dial_2_216824, LV_SIZE_CONTENT);
     lv_obj_set_height(face_75_2_dial_2_216824, LV_SIZE_CONTENT);
     lv_obj_set_x(face_75_2_dial_2_216824, 103);
@@ -249,35 +243,35 @@ void watchface_75_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_75_2_dial_2_216824, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_75_2_dial_2_216824, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_75_2_dial_3_59132 = lv_img_create(face_75_2_dial);
-    lv_img_set_src(face_75_2_dial_3_59132, &face_75_2_dial_3_59132_0);
+    face_75_2_dial_3_59132 = lv_image_create(face_75_2_dial);
+    lv_image_set_src(face_75_2_dial_3_59132, &face_75_2_dial_3_59132_0);
     lv_obj_set_width(face_75_2_dial_3_59132, LV_SIZE_CONTENT);
     lv_obj_set_height(face_75_2_dial_3_59132, LV_SIZE_CONTENT);
     lv_obj_set_x(face_75_2_dial_3_59132, 115);
     lv_obj_set_y(face_75_2_dial_3_59132, 59);
     lv_obj_add_flag(face_75_2_dial_3_59132, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_75_2_dial_3_59132, LV_OBJ_FLAG_SCROLLABLE);
-    lv_img_set_pivot(face_75_2_dial_3_59132, 5, 61);
+    lv_image_set_pivot(face_75_2_dial_3_59132, 5, 61);
 
-    face_75_2_dial_19_89191 = lv_img_create(face_75_2_dial);
-    lv_img_set_src(face_75_2_dial_19_89191, &face_75_2_dial_19_89191_0);
+    face_75_2_dial_19_89191 = lv_image_create(face_75_2_dial);
+    lv_image_set_src(face_75_2_dial_19_89191, &face_75_2_dial_19_89191_0);
     lv_obj_set_width(face_75_2_dial_19_89191, LV_SIZE_CONTENT);
     lv_obj_set_height(face_75_2_dial_19_89191, LV_SIZE_CONTENT);
     lv_obj_set_x(face_75_2_dial_19_89191, 115);
     lv_obj_set_y(face_75_2_dial_19_89191, 36);
     lv_obj_add_flag(face_75_2_dial_19_89191, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_75_2_dial_19_89191, LV_OBJ_FLAG_SCROLLABLE);
-    lv_img_set_pivot(face_75_2_dial_19_89191, 5, 84);
+    lv_image_set_pivot(face_75_2_dial_19_89191, 5, 84);
 
-    face_75_2_dial_35_138999 = lv_img_create(face_75_2_dial);
-    lv_img_set_src(face_75_2_dial_35_138999, &face_75_2_dial_35_138999_0);
+    face_75_2_dial_35_138999 = lv_image_create(face_75_2_dial);
+    lv_image_set_src(face_75_2_dial_35_138999, &face_75_2_dial_35_138999_0);
     lv_obj_set_width(face_75_2_dial_35_138999, LV_SIZE_CONTENT);
     lv_obj_set_height(face_75_2_dial_35_138999, LV_SIZE_CONTENT);
     lv_obj_set_x(face_75_2_dial_35_138999, 115);
     lv_obj_set_y(face_75_2_dial_35_138999, 12);
     lv_obj_add_flag(face_75_2_dial_35_138999, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_75_2_dial_35_138999, LV_OBJ_FLAG_SCROLLABLE);
-    lv_img_set_pivot(face_75_2_dial_35_138999, 5, 108);
+    lv_image_set_pivot(face_75_2_dial_35_138999, 5, 108);
 
     zsw_ui_notifications_area = zsw_ui_notification_area_add(face_75_2_dial);
     lv_obj_set_pos(zsw_ui_notifications_area->ui_notifications_container, 0, 70);

--- a/app/src/ui/watchfaces/79_2_dial/zsw_watchface_79_2_dial_ui.c
+++ b/app/src/ui/watchfaces/79_2_dial/zsw_watchface_79_2_dial_ui.c
@@ -16,7 +16,6 @@
 
 LOG_MODULE_REGISTER(watchface_79_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_79_2_dial;
 static lv_obj_t *face_79_2_dial = NULL;
 static watchface_app_evt_listener ui_79_2_dial_evt_cb;
 static zsw_ui_notification_area_t *zsw_ui_notifications_area;
@@ -165,20 +164,15 @@ const void *face_79_2_dial_19_144206_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_79_2_dial_remove(void)
@@ -222,50 +216,46 @@ static void watchface_79_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_79_2_dial_1_59582, face_79_2_dial_1_59582_group[(hour / 1) % 10]);
+        lv_image_set_src(face_79_2_dial_1_59582, face_79_2_dial_1_59582_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_79_2_dial_2_59582, face_79_2_dial_1_59582_group[(hour / 10) % 10]);
+        lv_image_set_src(face_79_2_dial_2_59582, face_79_2_dial_1_59582_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_79_2_dial_3_123330, face_79_2_dial_3_123330_group[(minute / 1) % 10]);
+        lv_image_set_src(face_79_2_dial_3_123330, face_79_2_dial_3_123330_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_79_2_dial_4_123330, face_79_2_dial_3_123330_group[(minute / 10) % 10]);
+        lv_image_set_src(face_79_2_dial_4_123330, face_79_2_dial_3_123330_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        last_month = setPlaceValue(last_month, 1, getPlaceValue(month, 1));
-        lv_img_set_src(face_79_2_dial_5_58512, face_79_2_dial_5_58512_group[(month / 1) % 10]);
+        lv_image_set_src(face_79_2_dial_5_58512, face_79_2_dial_5_58512_group[(month / 1) % 10]);
     }
 
     if (getPlaceValue(last_month, 2) != getPlaceValue(month, 2)) {
-        last_month = setPlaceValue(last_month, 2, getPlaceValue(month, 2));
-        lv_img_set_src(face_79_2_dial_6_58512, face_79_2_dial_5_58512_group[(month / 10) % 10]);
+        lv_image_set_src(face_79_2_dial_6_58512, face_79_2_dial_5_58512_group[(month / 10) % 10]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_79_2_dial_7_58512, face_79_2_dial_5_58512_group[(day / 1) % 10]);
+        lv_image_set_src(face_79_2_dial_7_58512, face_79_2_dial_5_58512_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_79_2_dial_8_58512, face_79_2_dial_5_58512_group[(day / 10) % 10]);
+        lv_image_set_src(face_79_2_dial_8_58512, face_79_2_dial_5_58512_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_79_2_dial_19_144206, face_79_2_dial_19_144206_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_79_2_dial_19_144206, face_79_2_dial_19_144206_group[((weekday + 6) / 1) % 7]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_month = month;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_79_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -275,30 +265,26 @@ static void watchface_79_2_dial_set_step(int32_t steps, int32_t distance, int32_
     }
 
     if (getPlaceValue(last_steps, 1) != getPlaceValue(steps, 1)) {
-        last_steps = setPlaceValue(last_steps, 1, getPlaceValue(steps, 1));
-        lv_img_set_src(face_79_2_dial_13_58512, face_79_2_dial_5_58512_group[(steps / 1) % 10]);
+        lv_image_set_src(face_79_2_dial_13_58512, face_79_2_dial_5_58512_group[(steps / 1) % 10]);
     }
 
     if (getPlaceValue(last_steps, 2) != getPlaceValue(steps, 2)) {
-        last_steps = setPlaceValue(last_steps, 2, getPlaceValue(steps, 2));
-        lv_img_set_src(face_79_2_dial_14_58512, face_79_2_dial_5_58512_group[(steps / 10) % 10]);
+        lv_image_set_src(face_79_2_dial_14_58512, face_79_2_dial_5_58512_group[(steps / 10) % 10]);
     }
 
     if (getPlaceValue(last_steps, 3) != getPlaceValue(steps, 3)) {
-        last_steps = setPlaceValue(last_steps, 3, getPlaceValue(steps, 3));
-        lv_img_set_src(face_79_2_dial_15_58512, face_79_2_dial_5_58512_group[(steps / 100) % 10]);
+        lv_image_set_src(face_79_2_dial_15_58512, face_79_2_dial_5_58512_group[(steps / 100) % 10]);
     }
 
     if (getPlaceValue(last_steps, 4) != getPlaceValue(steps, 4)) {
-        last_steps = setPlaceValue(last_steps, 4, getPlaceValue(steps, 4));
-        lv_img_set_src(face_79_2_dial_16_58512, face_79_2_dial_5_58512_group[(steps / 1000) % 10]);
+        lv_image_set_src(face_79_2_dial_16_58512, face_79_2_dial_5_58512_group[(steps / 1000) % 10]);
     }
 
     if (getPlaceValue(last_steps, 5) != getPlaceValue(steps, 5)) {
-        last_steps = setPlaceValue(last_steps, 5, getPlaceValue(steps, 5));
-        lv_img_set_src(face_79_2_dial_17_58512, face_79_2_dial_5_58512_group[(steps / 10000) % 10]);
+        lv_image_set_src(face_79_2_dial_17_58512, face_79_2_dial_5_58512_group[(steps / 10000) % 10]);
     }
 
+    last_steps = steps;
 }
 
 static void watchface_79_2_dial_set_hrm(int32_t bpm, int32_t oxygen)
@@ -332,9 +318,9 @@ static void watchface_79_2_dial_set_battery_percent(int32_t percent, int32_t bat
         return;
     }
 
-    lv_img_set_src(face_79_2_dial_10_58512, face_79_2_dial_5_58512_group[(percent / 1) % 10]);
-    lv_img_set_src(face_79_2_dial_11_58512, face_79_2_dial_5_58512_group[(percent / 10) % 10]);
-    lv_img_set_src(face_79_2_dial_12_58512, face_79_2_dial_5_58512_group[(percent / 100) % 10]);
+    lv_image_set_src(face_79_2_dial_10_58512, face_79_2_dial_5_58512_group[(percent / 1) % 10]);
+    lv_image_set_src(face_79_2_dial_11_58512, face_79_2_dial_5_58512_group[(percent / 10) % 10]);
+    lv_image_set_src(face_79_2_dial_12_58512, face_79_2_dial_5_58512_group[(percent / 100) % 10]);
     if (percent < 100) {
         lv_obj_add_flag(face_79_2_dial_12_58512, LV_OBJ_FLAG_HIDDEN);
     } else {
@@ -383,8 +369,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_79_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_79_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_79_2_dial_0_404 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_0_404, ZSW_LV_IMG_USE(face_79_2_dial_0_404_0));
+    face_79_2_dial_0_404 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_0_404, ZSW_LV_IMG_USE(face_79_2_dial_0_404_0));
     lv_obj_set_width(face_79_2_dial_0_404, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_0_404, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_0_404, 0);
@@ -392,8 +378,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_0_404, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_0_404, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_1_59582 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_1_59582, ZSW_LV_IMG_USE(face_79_2_dial_1_59582_0));
+    face_79_2_dial_1_59582 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_1_59582, ZSW_LV_IMG_USE(face_79_2_dial_1_59582_0));
     lv_obj_set_width(face_79_2_dial_1_59582, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_1_59582, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_1_59582, 82);
@@ -401,8 +387,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_1_59582, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_1_59582, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_2_59582 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_2_59582, ZSW_LV_IMG_USE(face_79_2_dial_1_59582_0));
+    face_79_2_dial_2_59582 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_2_59582, ZSW_LV_IMG_USE(face_79_2_dial_1_59582_0));
     lv_obj_set_width(face_79_2_dial_2_59582, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_2_59582, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_2_59582, 14);
@@ -410,8 +396,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_2_59582, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_2_59582, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_3_123330 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_3_123330, ZSW_LV_IMG_USE(face_79_2_dial_3_123330_0));
+    face_79_2_dial_3_123330 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_3_123330, ZSW_LV_IMG_USE(face_79_2_dial_3_123330_0));
     lv_obj_set_width(face_79_2_dial_3_123330, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_3_123330, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_3_123330, 188);
@@ -419,8 +405,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_3_123330, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_3_123330, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_4_123330 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_4_123330, ZSW_LV_IMG_USE(face_79_2_dial_3_123330_0));
+    face_79_2_dial_4_123330 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_4_123330, ZSW_LV_IMG_USE(face_79_2_dial_3_123330_0));
     lv_obj_set_width(face_79_2_dial_4_123330, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_4_123330, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_4_123330, 154);
@@ -428,8 +414,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_4_123330, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_4_123330, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_5_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_5_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_5_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_5_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_5_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_5_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_5_58512, 108);
@@ -437,8 +423,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_5_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_5_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_6_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_6_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_6_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_6_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_6_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_6_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_6_58512, 99);
@@ -446,8 +432,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_6_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_6_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_7_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_7_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_7_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_7_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_7_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_7_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_7_58512, 133);
@@ -455,8 +441,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_7_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_7_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_8_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_8_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_8_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_8_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_8_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_8_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_8_58512, 124);
@@ -464,8 +450,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_8_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_8_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_9_59456 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_9_59456, ZSW_LV_IMG_USE(face_79_2_dial_9_59456_0));
+    face_79_2_dial_9_59456 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_9_59456, ZSW_LV_IMG_USE(face_79_2_dial_9_59456_0));
     lv_obj_set_width(face_79_2_dial_9_59456, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_9_59456, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_9_59456, 116);
@@ -473,8 +459,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_9_59456, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_9_59456, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_10_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_10_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_10_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_10_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_10_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_10_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_10_58512, 67);
@@ -482,8 +468,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_10_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_10_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_11_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_11_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_11_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_11_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_11_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_11_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_11_58512, 58);
@@ -491,8 +477,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_11_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_11_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_12_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_12_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_12_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_12_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_12_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_12_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_12_58512, 49);
@@ -500,8 +486,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_12_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_12_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_13_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_13_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_13_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_13_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_13_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_13_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_13_58512, 195);
@@ -509,8 +495,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_13_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_13_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_14_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_14_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_14_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_14_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_14_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_14_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_14_58512, 186);
@@ -518,8 +504,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_14_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_14_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_15_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_15_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_15_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_15_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_15_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_15_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_15_58512, 177);
@@ -527,8 +513,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_15_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_15_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_16_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_16_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_16_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_16_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_16_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_16_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_16_58512, 168);
@@ -536,8 +522,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_16_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_16_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_17_58512 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_17_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
+    face_79_2_dial_17_58512 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_17_58512, ZSW_LV_IMG_USE(face_79_2_dial_5_58512_0));
     lv_obj_set_width(face_79_2_dial_17_58512, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_17_58512, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_17_58512, 159);
@@ -545,8 +531,8 @@ void watchface_79_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_79_2_dial_17_58512, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_79_2_dial_17_58512, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_79_2_dial_19_144206 = lv_img_create(face_79_2_dial);
-    lv_img_set_src(face_79_2_dial_19_144206, ZSW_LV_IMG_USE(face_79_2_dial_19_144206_0));
+    face_79_2_dial_19_144206 = lv_image_create(face_79_2_dial);
+    lv_image_set_src(face_79_2_dial_19_144206, ZSW_LV_IMG_USE(face_79_2_dial_19_144206_0));
     lv_obj_set_width(face_79_2_dial_19_144206, LV_SIZE_CONTENT);
     lv_obj_set_height(face_79_2_dial_19_144206, LV_SIZE_CONTENT);
     lv_obj_set_x(face_79_2_dial_19_144206, 74);

--- a/app/src/ui/watchfaces/80_2_dial/zsw_watchface_80_2_dial_ui.c
+++ b/app/src/ui/watchfaces/80_2_dial/zsw_watchface_80_2_dial_ui.c
@@ -20,7 +20,6 @@ LOG_MODULE_REGISTER(watchface_80_2_dial, LOG_LEVEL_WRN);
 #define USE_SLEEP       0
 #define USE_DISTANCE    0
 
-static lv_obj_t *face_80_2_dial;
 static lv_obj_t *face_80_2_dial = NULL;
 static watchface_app_evt_listener ui_80_2_dial_evt_cb;
 static zsw_ui_notification_area_t *zsw_ui_notifications_area;
@@ -264,20 +263,15 @@ const void *face_80_2_dial_weather[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_80_2_dial_remove(void)
@@ -321,70 +315,63 @@ static void watchface_80_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_80_2_dial_35_113802, face_80_2_dial_35_113802_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_80_2_dial_35_113802, face_80_2_dial_35_113802_group[((weekday + 6) / 1) % 7]);
     }
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_80_2_dial_37_96394, face_80_2_dial_37_96394_group[(hour / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_37_96394, face_80_2_dial_37_96394_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_80_2_dial_38_96394, face_80_2_dial_37_96394_group[(hour / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_38_96394, face_80_2_dial_37_96394_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_80_2_dial_39_96394, face_80_2_dial_37_96394_group[(minute / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_39_96394, face_80_2_dial_37_96394_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_80_2_dial_40_96394, face_80_2_dial_37_96394_group[(minute / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_40_96394, face_80_2_dial_37_96394_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_year, 1) != getPlaceValue(year, 1)) {
-        last_year = setPlaceValue(last_year, 1, getPlaceValue(year, 1));
-        lv_img_set_src(face_80_2_dial_43_86861, face_80_2_dial_43_86861_group[(year / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_43_86861, face_80_2_dial_43_86861_group[(year / 1) % 10]);
     }
 
     if (getPlaceValue(last_year, 2) != getPlaceValue(year, 2)) {
-        last_year = setPlaceValue(last_year, 2, getPlaceValue(year, 2));
-        lv_img_set_src(face_80_2_dial_44_86861, face_80_2_dial_43_86861_group[(year / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_44_86861, face_80_2_dial_43_86861_group[(year / 10) % 10]);
     }
 
     if (getPlaceValue(last_year, 3) != getPlaceValue(year, 3)) {
-        last_year = setPlaceValue(last_year, 3, getPlaceValue(year, 3));
-        lv_img_set_src(face_80_2_dial_45_86861, face_80_2_dial_43_86861_group[(year / 100) % 10]);
+        lv_image_set_src(face_80_2_dial_45_86861, face_80_2_dial_43_86861_group[(year / 100) % 10]);
     }
 
     if (getPlaceValue(last_year, 4) != getPlaceValue(year, 4)) {
-        last_year = setPlaceValue(last_year, 4, getPlaceValue(year, 4));
-        lv_img_set_src(face_80_2_dial_46_86861, face_80_2_dial_43_86861_group[(year / 1000) % 10]);
+        lv_image_set_src(face_80_2_dial_46_86861, face_80_2_dial_43_86861_group[(year / 1000) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        last_month = setPlaceValue(last_month, 1, getPlaceValue(month, 1));
-        lv_img_set_src(face_80_2_dial_47_86861, face_80_2_dial_43_86861_group[(month / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_47_86861, face_80_2_dial_43_86861_group[(month / 1) % 10]);
     }
 
     if (getPlaceValue(last_month, 2) != getPlaceValue(month, 2)) {
-        last_month = setPlaceValue(last_month, 2, getPlaceValue(month, 2));
-        lv_img_set_src(face_80_2_dial_48_86861, face_80_2_dial_43_86861_group[(month / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_48_86861, face_80_2_dial_43_86861_group[(month / 10) % 10]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_80_2_dial_49_86861, face_80_2_dial_43_86861_group[(day / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_49_86861, face_80_2_dial_43_86861_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_80_2_dial_50_86861, face_80_2_dial_43_86861_group[(day / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_50_86861, face_80_2_dial_43_86861_group[(day / 10) % 10]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_year = year;
+    last_month = month;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_80_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -394,65 +381,56 @@ static void watchface_80_2_dial_set_step(int32_t steps, int32_t distance, int32_
     }
 
     if (getPlaceValue(last_steps, 1) != getPlaceValue(steps, 1)) {
-        last_steps = setPlaceValue(last_steps, 1, getPlaceValue(steps, 1));
-        lv_img_set_src(face_80_2_dial_2_85197, face_80_2_dial_2_85197_group[(steps / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_2_85197, face_80_2_dial_2_85197_group[(steps / 1) % 10]);
     }
 
     if (getPlaceValue(last_steps, 2) != getPlaceValue(steps, 2)) {
-        last_steps = setPlaceValue(last_steps, 2, getPlaceValue(steps, 2));
-        lv_img_set_src(face_80_2_dial_3_85197, face_80_2_dial_2_85197_group[(steps / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_3_85197, face_80_2_dial_2_85197_group[(steps / 10) % 10]);
     }
 
     if (getPlaceValue(last_steps, 3) != getPlaceValue(steps, 3)) {
-        last_steps = setPlaceValue(last_steps, 3, getPlaceValue(steps, 3));
-        lv_img_set_src(face_80_2_dial_4_85197, face_80_2_dial_2_85197_group[(steps / 100) % 10]);
+        lv_image_set_src(face_80_2_dial_4_85197, face_80_2_dial_2_85197_group[(steps / 100) % 10]);
     }
 
     if (getPlaceValue(last_steps, 4) != getPlaceValue(steps, 4)) {
-        last_steps = setPlaceValue(last_steps, 4, getPlaceValue(steps, 4));
-        lv_img_set_src(face_80_2_dial_5_85197, face_80_2_dial_2_85197_group[(steps / 1000) % 10]);
+        lv_image_set_src(face_80_2_dial_5_85197, face_80_2_dial_2_85197_group[(steps / 1000) % 10]);
     }
 
     if (getPlaceValue(last_steps, 5) != getPlaceValue(steps, 5)) {
-        last_steps = setPlaceValue(last_steps, 5, getPlaceValue(steps, 5));
-        lv_img_set_src(face_80_2_dial_6_85197, face_80_2_dial_2_85197_group[(steps / 10000) % 10]);
+        lv_image_set_src(face_80_2_dial_6_85197, face_80_2_dial_2_85197_group[(steps / 10000) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 1) != getPlaceValue(kcal, 1)) {
-        last_kcal = setPlaceValue(last_kcal, 1, getPlaceValue(kcal, 1));
-        lv_img_set_src(face_80_2_dial_7_85197, face_80_2_dial_2_85197_group[(kcal / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_7_85197, face_80_2_dial_2_85197_group[(kcal / 1) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 2) != getPlaceValue(kcal, 2)) {
-        last_kcal = setPlaceValue(last_kcal, 2, getPlaceValue(kcal, 2));
-        lv_img_set_src(face_80_2_dial_8_85197, face_80_2_dial_2_85197_group[(kcal / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_8_85197, face_80_2_dial_2_85197_group[(kcal / 10) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 3) != getPlaceValue(kcal, 3)) {
-        last_kcal = setPlaceValue(last_kcal, 3, getPlaceValue(kcal, 3));
-        lv_img_set_src(face_80_2_dial_9_85197, face_80_2_dial_2_85197_group[(kcal / 100) % 10]);
+        lv_image_set_src(face_80_2_dial_9_85197, face_80_2_dial_2_85197_group[(kcal / 100) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 4) != getPlaceValue(kcal, 4)) {
-        last_kcal = setPlaceValue(last_kcal, 4, getPlaceValue(kcal, 4));
-        lv_img_set_src(face_80_2_dial_10_85197, face_80_2_dial_2_85197_group[(kcal / 1000) % 10]);
+        lv_image_set_src(face_80_2_dial_10_85197, face_80_2_dial_2_85197_group[(kcal / 1000) % 10]);
     }
 #if USE_DISTANCE
     if (getPlaceValue(last_distance, 1) != getPlaceValue(distance, 1)) {
-        last_distance = setPlaceValue(last_distance, 1, getPlaceValue(distance, 1));
-        lv_img_set_src(face_80_2_dial_23_85197, face_80_2_dial_2_85197_group[(distance / 1) % 10]);
+        lv_image_set_src(face_80_2_dial_23_85197, face_80_2_dial_2_85197_group[(distance / 1) % 10]);
     }
 
     if (getPlaceValue(last_distance, 2) != getPlaceValue(distance, 2)) {
-        last_distance = setPlaceValue(last_distance, 2, getPlaceValue(distance, 2));
-        lv_img_set_src(face_80_2_dial_24_85197, face_80_2_dial_2_85197_group[(distance / 10) % 10]);
+        lv_image_set_src(face_80_2_dial_24_85197, face_80_2_dial_2_85197_group[(distance / 10) % 10]);
     }
 
     if (getPlaceValue(last_distance, 3) != getPlaceValue(distance, 3)) {
-        last_distance = setPlaceValue(last_distance, 3, getPlaceValue(distance, 3));
-        lv_img_set_src(face_80_2_dial_25_85197, face_80_2_dial_2_85197_group[(distance / 100) % 10]);
+        lv_image_set_src(face_80_2_dial_25_85197, face_80_2_dial_2_85197_group[(distance / 100) % 10]);
     }
+    last_distance = distance;
 #endif
+    last_steps = steps;
+    last_kcal = kcal;
 }
 
 static void watchface_80_2_dial_set_hrm(int32_t bpm, int32_t oxygen)
@@ -461,9 +439,9 @@ static void watchface_80_2_dial_set_hrm(int32_t bpm, int32_t oxygen)
         return;
     }
 #if USE_HR
-    lv_img_set_src(face_80_2_dial_27_85197, face_80_2_dial_2_85197_group[(bpm / 1) % 10]);
-    lv_img_set_src(face_80_2_dial_28_85197, face_80_2_dial_2_85197_group[(bpm / 10) % 10]);
-    lv_img_set_src(face_80_2_dial_29_85197, face_80_2_dial_2_85197_group[(bpm / 100) % 10]);
+    lv_image_set_src(face_80_2_dial_27_85197, face_80_2_dial_2_85197_group[(bpm / 1) % 10]);
+    lv_image_set_src(face_80_2_dial_28_85197, face_80_2_dial_2_85197_group[(bpm / 10) % 10]);
+    lv_image_set_src(face_80_2_dial_29_85197, face_80_2_dial_2_85197_group[(bpm / 100) % 10]);
 #endif
 }
 
@@ -473,14 +451,14 @@ static void watchface_80_2_dial_set_weather(int8_t temp, int icon)
         return;
     }
 
-    lv_img_set_src(face_80_2_dial_53_86861, face_80_2_dial_43_86861_group[(temp / 1) % 10]);
-    lv_img_set_src(face_80_2_dial_54_86861, face_80_2_dial_43_86861_group[(temp / 10) % 10]);
+    lv_image_set_src(face_80_2_dial_53_86861, face_80_2_dial_43_86861_group[(temp / 1) % 10]);
+    lv_image_set_src(face_80_2_dial_54_86861, face_80_2_dial_43_86861_group[(temp / 10) % 10]);
     if (temp >= 0) {
         lv_obj_add_flag(face_80_2_dial_56_25742, LV_OBJ_FLAG_HIDDEN);
     } else {
         lv_obj_clear_flag(face_80_2_dial_56_25742, LV_OBJ_FLAG_HIDDEN);
     }
-    lv_img_set_src(face_80_2_dial_58_84569, face_80_2_dial_weather[icon % 8]);
+    lv_image_set_src(face_80_2_dial_58_84569, face_80_2_dial_weather[icon % 8]);
 
 }
 
@@ -541,8 +519,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_80_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_80_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_80_2_dial_0_2768 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_0_2768, ZSW_LV_IMG_USE(face_80_2_dial_0_2768_0));
+    face_80_2_dial_0_2768 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_0_2768, ZSW_LV_IMG_USE(face_80_2_dial_0_2768_0));
     lv_obj_set_width(face_80_2_dial_0_2768, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_0_2768, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_0_2768, 9);
@@ -550,8 +528,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_0_2768, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_0_2768, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_1_24923 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_1_24923, ZSW_LV_IMG_USE(face_80_2_dial_1_24923_0));
+    face_80_2_dial_1_24923 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_1_24923, ZSW_LV_IMG_USE(face_80_2_dial_1_24923_0));
     lv_obj_set_width(face_80_2_dial_1_24923, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_1_24923, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_1_24923, 123);
@@ -559,8 +537,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_1_24923, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_1_24923, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_2_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_2_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_2_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_2_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_2_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_2_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_2_85197, 98);
@@ -568,8 +546,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_2_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_2_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_3_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_3_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_3_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_3_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_3_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_3_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_3_85197, 85);
@@ -577,8 +555,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_3_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_3_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_4_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_4_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_4_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_4_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_4_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_4_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_4_85197, 72);
@@ -586,8 +564,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_4_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_4_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_5_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_5_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_5_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_5_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_5_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_5_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_5_85197, 59);
@@ -595,8 +573,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_5_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_5_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_6_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_6_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_6_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_6_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_6_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_6_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_6_85197, 46);
@@ -604,8 +582,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_6_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_6_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_7_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_7_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_7_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_7_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_7_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_7_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_7_85197, 175);
@@ -613,8 +591,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_7_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_7_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_8_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_8_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_8_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_8_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_8_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_8_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_8_85197, 162);
@@ -622,8 +600,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_8_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_8_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_9_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_9_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_9_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_9_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_9_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_9_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_9_85197, 149);
@@ -631,8 +609,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_9_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_9_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_10_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_10_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_10_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_10_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_10_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_10_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_10_85197, 136);
@@ -641,8 +619,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_clear_flag(face_80_2_dial_10_85197, LV_OBJ_FLAG_SCROLLABLE);
 
 #if USE_SLEEP
-    face_80_2_dial_12_94522 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_12_94522, ZSW_LV_IMG_USE(face_80_2_dial_12_94522_0));
+    face_80_2_dial_12_94522 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_12_94522, ZSW_LV_IMG_USE(face_80_2_dial_12_94522_0));
     lv_obj_set_width(face_80_2_dial_12_94522, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_12_94522, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_12_94522, 26);
@@ -650,8 +628,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_12_94522, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_12_94522, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_14_89131 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_14_89131, ZSW_LV_IMG_USE(face_80_2_dial_14_89131_0));
+    face_80_2_dial_14_89131 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_14_89131, ZSW_LV_IMG_USE(face_80_2_dial_14_89131_0));
     lv_obj_set_width(face_80_2_dial_14_89131, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_14_89131, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_14_89131, 51);
@@ -659,8 +637,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_14_89131, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_14_89131, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_16_89866 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_16_89866, ZSW_LV_IMG_USE(face_80_2_dial_16_89866_0));
+    face_80_2_dial_16_89866 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_16_89866, ZSW_LV_IMG_USE(face_80_2_dial_16_89866_0));
     lv_obj_set_width(face_80_2_dial_16_89866, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_16_89866, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_16_89866, 87);
@@ -668,8 +646,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_16_89866, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_16_89866, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_17_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_17_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_17_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_17_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_17_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_17_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_17_85197, 39);
@@ -677,8 +655,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_17_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_17_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_18_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_18_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_18_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_18_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_18_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_18_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_18_85197, 27);
@@ -686,8 +664,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_18_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_18_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_19_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_19_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_19_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_19_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_19_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_19_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_19_85197, 75);
@@ -695,8 +673,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_19_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_19_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_20_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_20_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_20_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_20_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_20_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_20_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_20_85197, 63);
@@ -706,8 +684,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
 #endif
 
 #if USE_DISTANCE
-    face_80_2_dial_21_89292 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_21_89292, ZSW_LV_IMG_USE(face_80_2_dial_21_89292_0));
+    face_80_2_dial_21_89292 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_21_89292, ZSW_LV_IMG_USE(face_80_2_dial_21_89292_0));
     lv_obj_set_width(face_80_2_dial_21_89292, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_21_89292, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_21_89292, 58);
@@ -715,8 +693,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_21_89292, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_21_89292, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_22_89272 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_22_89272, ZSW_LV_IMG_USE(face_80_2_dial_22_89272_0));
+    face_80_2_dial_22_89272 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_22_89272, ZSW_LV_IMG_USE(face_80_2_dial_22_89272_0));
     lv_obj_set_width(face_80_2_dial_22_89272, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_22_89272, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_22_89272, 91);
@@ -724,8 +702,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_22_89272, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_22_89272, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_23_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_23_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_23_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_23_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_23_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_23_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_23_85197, 108);
@@ -733,8 +711,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_23_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_23_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_24_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_24_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_24_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_24_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_24_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_24_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_24_85197, 96);
@@ -742,8 +720,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_24_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_24_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_25_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_25_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_25_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_25_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_25_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_25_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_25_85197, 78);
@@ -753,8 +731,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
 #endif
 
 #if USE_HR
-    face_80_2_dial_26_88651 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_26_88651, ZSW_LV_IMG_USE(face_80_2_dial_26_88651_0));
+    face_80_2_dial_26_88651 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_26_88651, ZSW_LV_IMG_USE(face_80_2_dial_26_88651_0));
     lv_obj_set_width(face_80_2_dial_26_88651, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_26_88651, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_26_88651, 85);
@@ -762,8 +740,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_26_88651, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_26_88651, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_27_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_27_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_27_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_27_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_27_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_27_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_27_85197, 131);
@@ -771,8 +749,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_27_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_27_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_28_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_28_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_28_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_28_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_28_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_28_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_28_85197, 119);
@@ -780,8 +758,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_28_85197, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_28_85197, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_29_85197 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_29_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
+    face_80_2_dial_29_85197 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_29_85197, ZSW_LV_IMG_USE(face_80_2_dial_2_85197_0));
     lv_obj_set_width(face_80_2_dial_29_85197, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_29_85197, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_29_85197, 107);
@@ -790,8 +768,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_clear_flag(face_80_2_dial_29_85197, LV_OBJ_FLAG_SCROLLABLE);
 #endif
 
-    face_80_2_dial_35_113802 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_35_113802, ZSW_LV_IMG_USE(face_80_2_dial_35_113802_0));
+    face_80_2_dial_35_113802 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_35_113802, ZSW_LV_IMG_USE(face_80_2_dial_35_113802_0));
     lv_obj_set_width(face_80_2_dial_35_113802, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_35_113802, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_35_113802, 98);
@@ -799,8 +777,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_35_113802, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_35_113802, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_36_96224 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_36_96224, ZSW_LV_IMG_USE(face_80_2_dial_36_96224_0));
+    face_80_2_dial_36_96224 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_36_96224, ZSW_LV_IMG_USE(face_80_2_dial_36_96224_0));
     lv_obj_set_width(face_80_2_dial_36_96224, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_36_96224, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_36_96224, 117);
@@ -808,8 +786,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_36_96224, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_36_96224, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_37_96394 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_37_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
+    face_80_2_dial_37_96394 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_37_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
     lv_obj_set_width(face_80_2_dial_37_96394, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_37_96394, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_37_96394, 79);
@@ -817,8 +795,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_37_96394, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_37_96394, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_38_96394 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_38_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
+    face_80_2_dial_38_96394 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_38_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
     lv_obj_set_width(face_80_2_dial_38_96394, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_38_96394, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_38_96394, 50);
@@ -826,8 +804,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_38_96394, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_38_96394, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_39_96394 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_39_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
+    face_80_2_dial_39_96394 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_39_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
     lv_obj_set_width(face_80_2_dial_39_96394, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_39_96394, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_39_96394, 166);
@@ -835,8 +813,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_39_96394, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_39_96394, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_40_96394 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_40_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
+    face_80_2_dial_40_96394 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_40_96394, ZSW_LV_IMG_USE(face_80_2_dial_37_96394_0));
     lv_obj_set_width(face_80_2_dial_40_96394, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_40_96394, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_40_96394, 137);
@@ -844,8 +822,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_40_96394, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_40_96394, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_41_86829 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_41_86829, ZSW_LV_IMG_USE(face_80_2_dial_41_86829_0));
+    face_80_2_dial_41_86829 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_41_86829, ZSW_LV_IMG_USE(face_80_2_dial_41_86829_0));
     lv_obj_set_width(face_80_2_dial_41_86829, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_41_86829, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_41_86829, 172);
@@ -853,8 +831,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_41_86829, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_41_86829, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_42_86829 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_42_86829, ZSW_LV_IMG_USE(face_80_2_dial_41_86829_0));
+    face_80_2_dial_42_86829 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_42_86829, ZSW_LV_IMG_USE(face_80_2_dial_41_86829_0));
     lv_obj_set_width(face_80_2_dial_42_86829, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_42_86829, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_42_86829, 139);
@@ -862,8 +840,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_42_86829, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_42_86829, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_43_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_43_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_43_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_43_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_43_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_43_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_43_86861, 127);
@@ -871,8 +849,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_43_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_43_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_44_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_44_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_44_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_44_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_44_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_44_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_44_86861, 115);
@@ -880,8 +858,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_44_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_44_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_45_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_45_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_45_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_45_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_45_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_45_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_45_86861, 103);
@@ -889,8 +867,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_45_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_45_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_46_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_46_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_46_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_46_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_46_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_46_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_46_86861, 91);
@@ -898,8 +876,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_46_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_46_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_47_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_47_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_47_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_47_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_47_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_47_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_47_86861, 160);
@@ -907,8 +885,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_47_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_47_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_48_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_48_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_48_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_48_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_48_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_48_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_48_86861, 148);
@@ -916,8 +894,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_48_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_48_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_49_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_49_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_49_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_49_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_49_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_49_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_49_86861, 193);
@@ -925,8 +903,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_49_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_49_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_50_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_50_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_50_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_50_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_50_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_50_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_50_86861, 181);
@@ -934,8 +912,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_50_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_50_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_53_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_53_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_53_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_53_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_53_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_53_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_53_86861, 60);
@@ -943,8 +921,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_53_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_53_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_54_86861 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_54_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
+    face_80_2_dial_54_86861 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_54_86861, ZSW_LV_IMG_USE(face_80_2_dial_43_86861_0));
     lv_obj_set_width(face_80_2_dial_54_86861, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_54_86861, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_54_86861, 48);
@@ -952,8 +930,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_54_86861, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_54_86861, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_55_106772 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_55_106772, ZSW_LV_IMG_USE(face_80_2_dial_55_106772_0));
+    face_80_2_dial_55_106772 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_55_106772, ZSW_LV_IMG_USE(face_80_2_dial_55_106772_0));
     lv_obj_set_width(face_80_2_dial_55_106772, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_55_106772, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_55_106772, 72);
@@ -961,8 +939,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_55_106772, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_55_106772, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_56_25742 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_56_25742, ZSW_LV_IMG_USE(face_80_2_dial_51_25742_0));
+    face_80_2_dial_56_25742 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_56_25742, ZSW_LV_IMG_USE(face_80_2_dial_51_25742_0));
     lv_obj_set_width(face_80_2_dial_56_25742, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_56_25742, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_56_25742, 42);
@@ -970,8 +948,8 @@ void watchface_80_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_80_2_dial_56_25742, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_80_2_dial_56_25742, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_80_2_dial_58_84569 = lv_img_create(face_80_2_dial);
-    lv_img_set_src(face_80_2_dial_58_84569, ZSW_LV_IMG_USE(face_80_2_dial_58_84569_0));
+    face_80_2_dial_58_84569 = lv_image_create(face_80_2_dial);
+    lv_image_set_src(face_80_2_dial_58_84569, ZSW_LV_IMG_USE(face_80_2_dial_58_84569_0));
     lv_obj_set_width(face_80_2_dial_58_84569, LV_SIZE_CONTENT);
     lv_obj_set_height(face_80_2_dial_58_84569, LV_SIZE_CONTENT);
     lv_obj_set_x(face_80_2_dial_58_84569, 20);

--- a/app/src/ui/watchfaces/84_2_dial/zsw_watchface_84_2_dial_ui.c
+++ b/app/src/ui/watchfaces/84_2_dial/zsw_watchface_84_2_dial_ui.c
@@ -146,20 +146,15 @@ const void *face_84_2_dial_12_247724_group[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_84_2_dial_remove(void)
@@ -203,50 +198,46 @@ static void watchface_84_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
         lv_img_set_src(face_84_2_dial_2_232486, face_84_2_dial_2_232486_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
         lv_img_set_src(face_84_2_dial_3_232486, face_84_2_dial_2_232486_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
         lv_img_set_src(face_84_2_dial_4_232486, face_84_2_dial_2_232486_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
         lv_img_set_src(face_84_2_dial_5_232486, face_84_2_dial_2_232486_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        last_month = setPlaceValue(last_month, 1, getPlaceValue(month, 1));
         lv_img_set_src(face_84_2_dial_7_231194, face_84_2_dial_7_231194_group[(month / 1) % 10]);
     }
 
     if (getPlaceValue(last_month, 2) != getPlaceValue(month, 2)) {
-        last_month = setPlaceValue(last_month, 2, getPlaceValue(month, 2));
         lv_img_set_src(face_84_2_dial_8_231194, face_84_2_dial_7_231194_group[(month / 10) % 10]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
         lv_img_set_src(face_84_2_dial_9_231194, face_84_2_dial_7_231194_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
         lv_img_set_src(face_84_2_dial_10_231194, face_84_2_dial_7_231194_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
         lv_img_set_src(face_84_2_dial_12_247724, face_84_2_dial_12_247724_group[((weekday + 6) / 1) % 7]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_month = month;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_84_2_dial_set_step(int32_t steps, int32_t distance, int32_t kcal)

--- a/app/src/ui/watchfaces/84_2_dial/zsw_watchface_84_2_dial_ui.c
+++ b/app/src/ui/watchfaces/84_2_dial/zsw_watchface_84_2_dial_ui.c
@@ -16,7 +16,6 @@
 
 LOG_MODULE_REGISTER(watchface_84_2_dial, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_84_2_dial;
 static lv_obj_t *face_84_2_dial = NULL;
 static watchface_app_evt_listener ui_84_2_dial_evt_cb;
 static zsw_ui_notification_area_t *zsw_ui_notifications_area;
@@ -198,39 +197,39 @@ static void watchface_84_2_dial_set_datetime(int day_of_week, int date, int day,
     month += 1;
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        lv_img_set_src(face_84_2_dial_2_232486, face_84_2_dial_2_232486_group[(hour / 1) % 10]);
+        lv_image_set_src(face_84_2_dial_2_232486, face_84_2_dial_2_232486_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        lv_img_set_src(face_84_2_dial_3_232486, face_84_2_dial_2_232486_group[(hour / 10) % 10]);
+        lv_image_set_src(face_84_2_dial_3_232486, face_84_2_dial_2_232486_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        lv_img_set_src(face_84_2_dial_4_232486, face_84_2_dial_2_232486_group[(minute / 1) % 10]);
+        lv_image_set_src(face_84_2_dial_4_232486, face_84_2_dial_2_232486_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        lv_img_set_src(face_84_2_dial_5_232486, face_84_2_dial_2_232486_group[(minute / 10) % 10]);
+        lv_image_set_src(face_84_2_dial_5_232486, face_84_2_dial_2_232486_group[(minute / 10) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        lv_img_set_src(face_84_2_dial_7_231194, face_84_2_dial_7_231194_group[(month / 1) % 10]);
+        lv_image_set_src(face_84_2_dial_7_231194, face_84_2_dial_7_231194_group[(month / 1) % 10]);
     }
 
     if (getPlaceValue(last_month, 2) != getPlaceValue(month, 2)) {
-        lv_img_set_src(face_84_2_dial_8_231194, face_84_2_dial_7_231194_group[(month / 10) % 10]);
+        lv_image_set_src(face_84_2_dial_8_231194, face_84_2_dial_7_231194_group[(month / 10) % 10]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        lv_img_set_src(face_84_2_dial_9_231194, face_84_2_dial_7_231194_group[(day / 1) % 10]);
+        lv_image_set_src(face_84_2_dial_9_231194, face_84_2_dial_7_231194_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        lv_img_set_src(face_84_2_dial_10_231194, face_84_2_dial_7_231194_group[(day / 10) % 10]);
+        lv_image_set_src(face_84_2_dial_10_231194, face_84_2_dial_7_231194_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        lv_img_set_src(face_84_2_dial_12_247724, face_84_2_dial_12_247724_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_84_2_dial_12_247724, face_84_2_dial_12_247724_group[((weekday + 6) / 1) % 7]);
     }
 
     last_hour = hour;
@@ -321,8 +320,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_set_style_pad_top(face_84_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_84_2_dial, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_84_2_dial_0_264 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_0_264, ZSW_LV_IMG_USE(face_84_2_dial_0_264_0));
+    face_84_2_dial_0_264 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_0_264, ZSW_LV_IMG_USE(face_84_2_dial_0_264_0));
     lv_obj_set_width(face_84_2_dial_0_264, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_0_264, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_0_264, 0);
@@ -330,8 +329,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_0_264, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_0_264, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_1_232268 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_1_232268, ZSW_LV_IMG_USE(face_84_2_dial_1_232268_0));
+    face_84_2_dial_1_232268 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_1_232268, ZSW_LV_IMG_USE(face_84_2_dial_1_232268_0));
     lv_obj_set_width(face_84_2_dial_1_232268, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_1_232268, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_1_232268, 115);
@@ -339,8 +338,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_1_232268, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_1_232268, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_2_232486 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_2_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
+    face_84_2_dial_2_232486 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_2_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
     lv_obj_set_width(face_84_2_dial_2_232486, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_2_232486, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_2_232486, 78);
@@ -348,8 +347,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_2_232486, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_2_232486, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_3_232486 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_3_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
+    face_84_2_dial_3_232486 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_3_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
     lv_obj_set_width(face_84_2_dial_3_232486, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_3_232486, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_3_232486, 43);
@@ -357,8 +356,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_3_232486, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_3_232486, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_4_232486 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_4_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
+    face_84_2_dial_4_232486 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_4_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
     lv_obj_set_width(face_84_2_dial_4_232486, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_4_232486, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_4_232486, 169);
@@ -366,8 +365,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_4_232486, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_4_232486, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_5_232486 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_5_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
+    face_84_2_dial_5_232486 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_5_232486, ZSW_LV_IMG_USE(face_84_2_dial_2_232486_0));
     lv_obj_set_width(face_84_2_dial_5_232486, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_5_232486, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_5_232486, 134);
@@ -375,8 +374,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_5_232486, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_5_232486, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_6_231174 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_6_231174, ZSW_LV_IMG_USE(face_84_2_dial_6_231174_0));
+    face_84_2_dial_6_231174 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_6_231174, ZSW_LV_IMG_USE(face_84_2_dial_6_231174_0));
     lv_obj_set_width(face_84_2_dial_6_231174, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_6_231174, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_6_231174, 88);
@@ -384,8 +383,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_6_231174, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_6_231174, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_7_231194 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_7_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
+    face_84_2_dial_7_231194 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_7_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
     lv_obj_set_width(face_84_2_dial_7_231194, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_7_231194, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_7_231194, 79);
@@ -393,8 +392,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_7_231194, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_7_231194, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_8_231194 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_8_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
+    face_84_2_dial_8_231194 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_8_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
     lv_obj_set_width(face_84_2_dial_8_231194, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_8_231194, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_8_231194, 70);
@@ -402,8 +401,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_8_231194, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_8_231194, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_9_231194 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_9_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
+    face_84_2_dial_9_231194 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_9_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
     lv_obj_set_width(face_84_2_dial_9_231194, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_9_231194, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_9_231194, 104);
@@ -411,8 +410,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_9_231194, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_9_231194, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_10_231194 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_10_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
+    face_84_2_dial_10_231194 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_10_231194, ZSW_LV_IMG_USE(face_84_2_dial_7_231194_0));
     lv_obj_set_width(face_84_2_dial_10_231194, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_10_231194, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_10_231194, 95);
@@ -420,8 +419,8 @@ void watchface_84_2_dial_show(lv_obj_t *parent, watchface_app_evt_listener evt_c
     lv_obj_add_flag(face_84_2_dial_10_231194, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_84_2_dial_10_231194, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_84_2_dial_12_247724 = lv_img_create(face_84_2_dial);
-    lv_img_set_src(face_84_2_dial_12_247724, ZSW_LV_IMG_USE(face_84_2_dial_12_247724_0));
+    face_84_2_dial_12_247724 = lv_image_create(face_84_2_dial);
+    lv_image_set_src(face_84_2_dial_12_247724, ZSW_LV_IMG_USE(face_84_2_dial_12_247724_0));
     lv_obj_set_width(face_84_2_dial_12_247724, LV_SIZE_CONTENT);
     lv_obj_set_height(face_84_2_dial_12_247724, LV_SIZE_CONTENT);
     lv_obj_set_x(face_84_2_dial_12_247724, 135);

--- a/app/src/ui/watchfaces/digital/zsw_watchface_digital_ui.c
+++ b/app/src/ui/watchfaces/digital/zsw_watchface_digital_ui.c
@@ -154,14 +154,14 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_style_bg_color(ui_co2_arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(ui_co2_arc, 0, LV_PART_KNOB | LV_STATE_DEFAULT);
 
-    ui_iaq_co2_text_image = lv_img_create(ui_co2_arc);
-    lv_img_set_src(ui_iaq_co2_text_image, ZSW_LV_IMG_USE(ui_img_pressure_png));
+    ui_iaq_co2_text_image = lv_image_create(ui_co2_arc);
+    lv_image_set_src(ui_iaq_co2_text_image, ZSW_LV_IMG_USE(ui_img_pressure_png));
     lv_obj_set_width(ui_iaq_co2_text_image, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_iaq_co2_text_image, LV_SIZE_CONTENT);
     lv_obj_set_pos(ui_iaq_co2_text_image, -80, -70);
     lv_obj_set_align(ui_iaq_co2_text_image, LV_ALIGN_CENTER);
-    lv_img_set_src(ui_iaq_co2_text_image, &ui_img_iaq_co2_text);
-    lv_img_set_angle(ui_iaq_co2_text_image, 300);
+    lv_image_set_src(ui_iaq_co2_text_image, &ui_img_iaq_co2_text);
+    lv_image_set_rotation(ui_iaq_co2_text_image, 300);
     lv_obj_add_flag(ui_iaq_co2_text_image, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_clear_flag(ui_iaq_co2_text_image,
                       LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC |
@@ -169,8 +169,8 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_style_img_recolor(ui_iaq_co2_text_image, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_img_recolor_opa(ui_iaq_co2_text_image, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 #else
-    ui_pressure_image = lv_img_create(ui_iaq_or_pressure_arc);
-    lv_img_set_src(ui_pressure_image, ZSW_LV_IMG_USE(ui_img_pressure_png));
+    ui_pressure_image = lv_image_create(ui_iaq_or_pressure_arc);
+    lv_image_set_src(ui_pressure_image, ZSW_LV_IMG_USE(ui_img_pressure_png));
     lv_obj_set_width(ui_pressure_image, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_pressure_image, LV_SIZE_CONTENT);
     lv_obj_set_x(ui_pressure_image, -70);
@@ -206,8 +206,8 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_style_bg_color(ui_humidity_arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(ui_humidity_arc, 0, LV_PART_KNOB | LV_STATE_DEFAULT);
 
-    ui_humidity_icon = lv_img_create(ui_humidity_arc);
-    lv_img_set_src(ui_humidity_icon, ZSW_LV_IMG_USE(ui_img_temperatures_png));
+    ui_humidity_icon = lv_image_create(ui_humidity_arc);
+    lv_image_set_src(ui_humidity_icon, ZSW_LV_IMG_USE(ui_img_temperatures_png));
     lv_obj_set_width(ui_humidity_icon, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_humidity_icon, LV_SIZE_CONTENT);
     lv_obj_set_x(ui_humidity_icon, 70);
@@ -331,8 +331,8 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_style_bg_color(ui_battery_arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(ui_battery_arc, 0, LV_PART_KNOB | LV_STATE_DEFAULT);
 
-    ui_battery_arc_icon = lv_img_create(ui_battery_arc);
-    lv_img_set_src(ui_battery_arc_icon, ZSW_LV_IMG_USE(ui_img_charging_png));
+    ui_battery_arc_icon = lv_image_create(ui_battery_arc);
+    lv_image_set_src(ui_battery_arc_icon, ZSW_LV_IMG_USE(ui_img_charging_png));
     lv_obj_set_width(ui_battery_arc_icon, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_battery_arc_icon, LV_SIZE_CONTENT);
     lv_obj_set_align(ui_battery_arc_icon, LV_ALIGN_CENTER);
@@ -374,8 +374,8 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_style_bg_color(ui_step_arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(ui_step_arc, 0, LV_PART_KNOB | LV_STATE_DEFAULT);
 
-    ui_step_arc_icon = lv_img_create(ui_step_arc);
-    lv_img_set_src(ui_step_arc_icon, ZSW_LV_IMG_USE(ui_img_running_png));
+    ui_step_arc_icon = lv_image_create(ui_step_arc);
+    lv_image_set_src(ui_step_arc_icon, ZSW_LV_IMG_USE(ui_img_running_png));
     lv_obj_set_width(ui_step_arc_icon, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_step_arc_icon, LV_SIZE_CONTENT);
     lv_obj_set_align(ui_step_arc_icon, LV_ALIGN_CENTER);
@@ -449,12 +449,12 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
                       LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_SNAPPABLE | LV_OBJ_FLAG_SCROLLABLE |
                       LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN);
 
-    ui_weather_icon = lv_img_create(ui_digital_watchface);
+    ui_weather_icon = lv_image_create(ui_digital_watchface);
     lv_color_t icon_color;
 
     // Just use a default dummy image by default
     const lv_img_dsc_t *icon = zsw_ui_utils_icon_from_weather_code(802, &icon_color);
-    lv_img_set_src(ui_weather_icon, icon);
+    lv_image_set_src(ui_weather_icon, icon);
     lv_obj_set_width(ui_weather_icon, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_weather_icon, LV_SIZE_CONTENT);
     lv_obj_set_x(ui_weather_icon, -12);
@@ -547,7 +547,7 @@ static void watchface_set_weather(int8_t temperature, int weather_code)
 
     lv_label_set_text_fmt(ui_weather_temperature_label, "%d°", temperature);
     icon = zsw_ui_utils_icon_from_weather_code(weather_code, &icon_color);
-    lv_img_set_src(ui_weather_icon, icon);
+    lv_image_set_src(ui_weather_icon, icon);
 
     lv_obj_set_style_img_recolor_opa(ui_weather_icon, LV_OPA_COVER, 0);
     lv_obj_set_style_img_recolor(ui_weather_icon, icon_color, 0);

--- a/app/src/ui/watchfaces/minimal/zsw_watchface_minimal_ui.c
+++ b/app/src/ui/watchfaces/minimal/zsw_watchface_minimal_ui.c
@@ -69,27 +69,27 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_clear_flag(ui_minimal_watchface, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
     lv_obj_set_style_bg_img_src(ui_minimal_watchface, global_watchface_bg_img, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    ui_hour_img = lv_img_create(ui_minimal_watchface);
-    lv_img_set_src(ui_hour_img, &hour_minimal);
+    ui_hour_img = lv_image_create(ui_minimal_watchface);
+    lv_image_set_src(ui_hour_img, &hour_minimal);
     lv_obj_set_width(ui_hour_img, LV_SIZE_CONTENT);   /// 25
     lv_obj_set_height(ui_hour_img, LV_SIZE_CONTENT);    /// 89
     lv_obj_set_x(ui_hour_img, 0);
     lv_obj_set_y(ui_hour_img, -32);
     lv_obj_set_align(ui_hour_img, LV_ALIGN_CENTER);
     lv_obj_clear_flag(ui_hour_img, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
-    lv_img_set_pivot(ui_hour_img, 18, 82);
+    lv_image_set_pivot(ui_hour_img, 18, 82);
     lv_obj_set_style_img_recolor(ui_hour_img, lv_color_hex(0x0EA7FF), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_img_recolor_opa(ui_hour_img, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    ui_min_img = lv_img_create(ui_minimal_watchface);
-    lv_img_set_src(ui_min_img, &minute_minimal);
+    ui_min_img = lv_image_create(ui_minimal_watchface);
+    lv_image_set_src(ui_min_img, &minute_minimal);
     lv_obj_set_width(ui_min_img, LV_SIZE_CONTENT);   /// 12
     lv_obj_set_height(ui_min_img, LV_SIZE_CONTENT);    /// 104
     lv_obj_set_x(ui_min_img, 0);
     lv_obj_set_y(ui_min_img, -46);
     lv_obj_set_align(ui_min_img, LV_ALIGN_CENTER);
     lv_obj_clear_flag(ui_min_img, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
-    lv_img_set_pivot(ui_min_img, 11, 104);
+    lv_image_set_pivot(ui_min_img, 11, 104);
     lv_obj_set_style_img_recolor(ui_min_img, lv_color_hex(0xF0FFD5), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_img_recolor_opa(ui_min_img, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -103,8 +103,8 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_style_text_color(ui_day_data_label, lv_color_hex(0xCF9C60), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_opa(ui_day_data_label, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    ui_second_img = lv_img_create(ui_minimal_watchface);
-    lv_img_set_src(ui_second_img, &second_minimal);
+    ui_second_img = lv_image_create(ui_minimal_watchface);
+    lv_image_set_src(ui_second_img, &second_minimal);
     lv_obj_set_width(ui_second_img, LV_SIZE_CONTENT);   /// 1
     lv_obj_set_height(ui_second_img, LV_SIZE_CONTENT);    /// 1
     lv_obj_set_x(ui_second_img, -1);
@@ -112,7 +112,7 @@ static void watchface_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, 
     lv_obj_set_align(ui_second_img, LV_ALIGN_CENTER);
     lv_obj_add_flag(ui_second_img, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_second_img, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
-    lv_img_set_pivot(ui_second_img, 4, 108);
+    lv_image_set_pivot(ui_second_img, 4, 108);
     lv_obj_set_style_img_recolor(ui_second_img, lv_color_hex(0xFF4242), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_img_recolor_opa(ui_second_img, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -191,11 +191,11 @@ static void watchface_set_datetime(int day_of_week, int date, int day, int month
     last_hour = hour_minute_offset + hour * (3600 / 12);
     last_minute = minute * (3600 / 60);
     last_second = second * (3600 / 60);
-    lv_img_set_angle(ui_hour_img, last_hour);
-    lv_img_set_angle(ui_min_img, last_minute);
+    lv_image_set_rotation(ui_hour_img, last_hour);
+    lv_image_set_rotation(ui_min_img, last_minute);
 
     last_second += lv_map(usec, 0, 999999, 0, 3600 / 60);
-    lv_img_set_angle(ui_second_img, last_second);
+    lv_image_set_rotation(ui_second_img, last_second);
 }
 
 static void watchface_set_watch_env_sensors(int temperature, int humidity, int pressure, float iaq, float co2)

--- a/app/src/ui/watchfaces/pixel/zsw_watchface_goog_ui.c
+++ b/app/src/ui/watchfaces/pixel/zsw_watchface_goog_ui.c
@@ -15,7 +15,6 @@
 
 LOG_MODULE_REGISTER(watchface_goog, LOG_LEVEL_WRN);
 
-static lv_obj_t *face_goog;
 static lv_obj_t *face_goog = NULL;
 static watchface_app_evt_listener ui_goog_evt_cb;
 
@@ -246,20 +245,15 @@ const void *face_goog_weather[] = {
 
 static int32_t getPlaceValue(int32_t num, int32_t place)
 {
+    if (num < 0) {
+        return -1;
+    }
+
     int32_t divisor = 1;
     for (uint32_t i = 1; i < place; i++) {
         divisor *= 10;
     }
     return (num / divisor) % 10;
-}
-
-static int32_t setPlaceValue(int32_t num, int32_t place, int32_t newValue)
-{
-    int32_t divisor = 1;
-    for (uint32_t i = 1; i < place; i++) {
-        divisor *= 10;
-    }
-    return num - ((num / divisor) % 10 * divisor) + (newValue * divisor);
 }
 
 static void watchface_goog_remove(void)
@@ -302,45 +296,42 @@ static void watchface_goog_set_datetime(int day_of_week, int date, int day, int 
     month += 1;
 
     if (getPlaceValue(last_weekday, 1) != getPlaceValue(weekday, 1)) {
-        last_weekday = setPlaceValue(last_weekday, 1, getPlaceValue(weekday, 1));
-        lv_img_set_src(face_goog_22_72744, face_goog_22_72744_group[((weekday + 6) / 1) % 7]);
+        lv_image_set_src(face_goog_22_72744, face_goog_22_72744_group[((weekday + 6) / 1) % 7]);
     }
 
     if (getPlaceValue(last_day, 1) != getPlaceValue(day, 1)) {
-        last_day = setPlaceValue(last_day, 1, getPlaceValue(day, 1));
-        lv_img_set_src(face_goog_23_59114, face_goog_1_59114_group[(day / 1) % 10]);
+        lv_image_set_src(face_goog_23_59114, face_goog_1_59114_group[(day / 1) % 10]);
     }
 
     if (getPlaceValue(last_day, 2) != getPlaceValue(day, 2)) {
-        last_day = setPlaceValue(last_day, 2, getPlaceValue(day, 2));
-        lv_img_set_src(face_goog_24_59114, face_goog_1_59114_group[(day / 10) % 10]);
+        lv_image_set_src(face_goog_24_59114, face_goog_1_59114_group[(day / 10) % 10]);
     }
 
     if (getPlaceValue(last_month, 1) != getPlaceValue(month, 1)) {
-        last_month = setPlaceValue(last_month, 1, getPlaceValue(month, 1));
-        lv_img_set_src(face_goog_27_87610, face_goog_27_87610_group[(month / 1) % 12]);
+        lv_image_set_src(face_goog_27_87610, face_goog_27_87610_group[(month / 1) % 12]);
     }
 
     if (getPlaceValue(last_hour, 1) != getPlaceValue(hour, 1)) {
-        last_hour = setPlaceValue(last_hour, 1, getPlaceValue(hour, 1));
-        lv_img_set_src(face_goog_28_97966, face_goog_28_97966_group[(hour / 1) % 10]);
+        lv_image_set_src(face_goog_28_97966, face_goog_28_97966_group[(hour / 1) % 10]);
     }
 
     if (getPlaceValue(last_hour, 2) != getPlaceValue(hour, 2)) {
-        last_hour = setPlaceValue(last_hour, 2, getPlaceValue(hour, 2));
-        lv_img_set_src(face_goog_29_97966, face_goog_28_97966_group[(hour / 10) % 10]);
+        lv_image_set_src(face_goog_29_97966, face_goog_28_97966_group[(hour / 10) % 10]);
     }
 
     if (getPlaceValue(last_minute, 1) != getPlaceValue(minute, 1)) {
-        last_minute = setPlaceValue(last_minute, 1, getPlaceValue(minute, 1));
-        lv_img_set_src(face_goog_30_97966, face_goog_28_97966_group[(minute / 1) % 10]);
+        lv_image_set_src(face_goog_30_97966, face_goog_28_97966_group[(minute / 1) % 10]);
     }
 
     if (getPlaceValue(last_minute, 2) != getPlaceValue(minute, 2)) {
-        last_minute = setPlaceValue(last_minute, 2, getPlaceValue(minute, 2));
-        lv_img_set_src(face_goog_31_97966, face_goog_28_97966_group[(minute / 10) % 10]);
+        lv_image_set_src(face_goog_31_97966, face_goog_28_97966_group[(minute / 10) % 10]);
     }
 
+    last_hour = hour;
+    last_minute = minute;
+    last_month = month;
+    last_day = day;
+    last_weekday = weekday;
 }
 
 static void watchface_goog_set_step(int32_t steps, int32_t distance, int32_t kcal)
@@ -350,50 +341,43 @@ static void watchface_goog_set_step(int32_t steps, int32_t distance, int32_t kca
     }
 
     if (getPlaceValue(last_steps, 1) != getPlaceValue(steps, 1)) {
-        last_steps = setPlaceValue(last_steps, 1, getPlaceValue(steps, 1));
-        lv_img_set_src(face_goog_1_59114, face_goog_1_59114_group[(steps / 1) % 10]);
+        lv_image_set_src(face_goog_1_59114, face_goog_1_59114_group[(steps / 1) % 10]);
     }
 
     if (getPlaceValue(last_steps, 2) != getPlaceValue(steps, 2)) {
-        last_steps = setPlaceValue(last_steps, 2, getPlaceValue(steps, 2));
-        lv_img_set_src(face_goog_2_59114, face_goog_1_59114_group[(steps / 10) % 10]);
+        lv_image_set_src(face_goog_2_59114, face_goog_1_59114_group[(steps / 10) % 10]);
     }
 
     if (getPlaceValue(last_steps, 3) != getPlaceValue(steps, 3)) {
-        last_steps = setPlaceValue(last_steps, 3, getPlaceValue(steps, 3));
-        lv_img_set_src(face_goog_3_59114, face_goog_1_59114_group[(steps / 100) % 10]);
+        lv_image_set_src(face_goog_3_59114, face_goog_1_59114_group[(steps / 100) % 10]);
     }
 
     if (getPlaceValue(last_steps, 4) != getPlaceValue(steps, 4)) {
-        last_steps = setPlaceValue(last_steps, 4, getPlaceValue(steps, 4));
-        lv_img_set_src(face_goog_4_59114, face_goog_1_59114_group[(steps / 1000) % 10]);
+        lv_image_set_src(face_goog_4_59114, face_goog_1_59114_group[(steps / 1000) % 10]);
     }
 
     if (getPlaceValue(last_steps, 5) != getPlaceValue(steps, 5)) {
-        last_steps = setPlaceValue(last_steps, 5, getPlaceValue(steps, 5));
-        lv_img_set_src(face_goog_5_59114, face_goog_1_59114_group[(steps / 10000) % 10]);
+        lv_image_set_src(face_goog_5_59114, face_goog_1_59114_group[(steps / 10000) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 1) != getPlaceValue(kcal, 1)) {
-        last_kcal = setPlaceValue(last_kcal, 1, getPlaceValue(kcal, 1));
-        lv_img_set_src(face_goog_6_59114, face_goog_1_59114_group[(kcal / 1) % 10]);
+        lv_image_set_src(face_goog_6_59114, face_goog_1_59114_group[(kcal / 1) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 2) != getPlaceValue(kcal, 2)) {
-        last_kcal = setPlaceValue(last_kcal, 2, getPlaceValue(kcal, 2));
-        lv_img_set_src(face_goog_7_59114, face_goog_1_59114_group[(kcal / 10) % 10]);
+        lv_image_set_src(face_goog_7_59114, face_goog_1_59114_group[(kcal / 10) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 3) != getPlaceValue(kcal, 3)) {
-        last_kcal = setPlaceValue(last_kcal, 3, getPlaceValue(kcal, 3));
-        lv_img_set_src(face_goog_8_59114, face_goog_1_59114_group[(kcal / 100) % 10]);
+        lv_image_set_src(face_goog_8_59114, face_goog_1_59114_group[(kcal / 100) % 10]);
     }
 
     if (getPlaceValue(last_kcal, 4) != getPlaceValue(kcal, 4)) {
-        last_kcal = setPlaceValue(last_kcal, 4, getPlaceValue(kcal, 4));
-        lv_img_set_src(face_goog_9_59114, face_goog_1_59114_group[(kcal / 1000) % 10]);
+        lv_image_set_src(face_goog_9_59114, face_goog_1_59114_group[(kcal / 1000) % 10]);
     }
 
+    last_steps = steps;
+    last_kcal = kcal;
 }
 
 static void watchface_goog_set_hrm(int32_t bpm, int32_t oxygen)
@@ -402,9 +386,9 @@ static void watchface_goog_set_hrm(int32_t bpm, int32_t oxygen)
         return;
     }
 
-    lv_img_set_src(face_goog_13_59114, face_goog_1_59114_group[(bpm / 1) % 10]);
-    lv_img_set_src(face_goog_14_59114, face_goog_1_59114_group[(bpm / 10) % 10]);
-    lv_img_set_src(face_goog_15_59114, face_goog_1_59114_group[(bpm / 100) % 10]);
+    lv_image_set_src(face_goog_13_59114, face_goog_1_59114_group[(bpm / 1) % 10]);
+    lv_image_set_src(face_goog_14_59114, face_goog_1_59114_group[(bpm / 10) % 10]);
+    lv_image_set_src(face_goog_15_59114, face_goog_1_59114_group[(bpm / 100) % 10]);
 
 }
 
@@ -414,14 +398,14 @@ static void watchface_goog_set_weather(int8_t temp, int icon)
         return;
     }
 
-    lv_img_set_src(face_goog_34_59114, face_goog_1_59114_group[(temp / 1) % 10]);
-    lv_img_set_src(face_goog_35_59114, face_goog_1_59114_group[(temp / 10) % 10]);
+    lv_image_set_src(face_goog_34_59114, face_goog_1_59114_group[(temp / 1) % 10]);
+    lv_image_set_src(face_goog_35_59114, face_goog_1_59114_group[(temp / 10) % 10]);
     if (temp >= 0) {
         lv_obj_add_flag(face_goog_37_65535, LV_OBJ_FLAG_HIDDEN);
     } else {
         lv_obj_clear_flag(face_goog_37_65535, LV_OBJ_FLAG_HIDDEN);
     }
-    lv_img_set_src(face_goog_41_130994, face_goog_weather[icon % 8]);
+    lv_image_set_src(face_goog_41_130994, face_goog_weather[icon % 8]);
 
 }
 
@@ -439,15 +423,15 @@ static void watchface_goog_set_battery_percent(int32_t percent, int32_t battery)
         return;
     }
 
-    lv_img_set_src(face_goog_16_59114, face_goog_1_59114_group[(percent / 1) % 10]);
-    lv_img_set_src(face_goog_17_59114, face_goog_1_59114_group[(percent / 10) % 10]);
-    lv_img_set_src(face_goog_18_59114, face_goog_1_59114_group[(percent / 100) % 10]);
+    lv_image_set_src(face_goog_16_59114, face_goog_1_59114_group[(percent / 1) % 10]);
+    lv_image_set_src(face_goog_17_59114, face_goog_1_59114_group[(percent / 10) % 10]);
+    lv_image_set_src(face_goog_18_59114, face_goog_1_59114_group[(percent / 100) % 10]);
     if (percent < 100) {
         lv_obj_add_flag(face_goog_18_59114, LV_OBJ_FLAG_HIDDEN);
     } else {
         lv_obj_clear_flag(face_goog_18_59114, LV_OBJ_FLAG_HIDDEN);
     }
-    lv_img_set_src(face_goog_20_61728, face_goog_20_61728_group[lv_map(percent, 0, 100, 0, 6)]);
+    lv_image_set_src(face_goog_20_61728, face_goog_20_61728_group[lv_map(percent, 0, 100, 0, 6)]);
 }
 
 static void watchface_goog_set_num_notifcations(int32_t number)
@@ -489,8 +473,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_set_style_pad_top(face_goog, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(face_goog, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    face_goog_0_1004 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_0_1004, ZSW_LV_IMG_USE(face_goog_0_1004_0));
+    face_goog_0_1004 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_0_1004, ZSW_LV_IMG_USE(face_goog_0_1004_0));
     lv_obj_set_width(face_goog_0_1004, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_0_1004, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_0_1004, 0);
@@ -498,8 +482,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_0_1004, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_0_1004, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_1_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_1_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_1_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_1_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_1_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_1_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_1_59114, 118);
@@ -507,8 +491,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_1_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_1_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_2_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_2_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_2_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_2_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_2_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_2_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_2_59114, 111);
@@ -516,8 +500,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_2_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_2_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_3_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_3_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_3_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_3_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_3_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_3_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_3_59114, 104);
@@ -525,8 +509,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_3_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_3_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_4_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_4_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_4_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_4_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_4_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_4_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_4_59114, 96);
@@ -534,8 +518,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_4_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_4_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_5_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_5_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_5_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_5_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_5_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_5_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_5_59114, 89);
@@ -543,8 +527,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_5_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_5_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_6_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_6_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_6_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_6_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_6_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_6_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_6_59114, 146);
@@ -552,8 +536,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_6_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_6_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_7_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_7_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_7_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_7_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_7_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_7_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_7_59114, 139);
@@ -561,8 +545,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_7_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_7_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_8_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_8_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_8_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_8_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_8_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_8_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_8_59114, 132);
@@ -570,8 +554,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_8_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_8_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_9_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_9_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_9_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_9_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_9_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_9_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_9_59114, 124);
@@ -579,8 +563,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_9_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_9_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_12_60913 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_12_60913, ZSW_LV_IMG_USE(face_goog_12_60913_0));
+    face_goog_12_60913 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_12_60913, ZSW_LV_IMG_USE(face_goog_12_60913_0));
     lv_obj_set_width(face_goog_12_60913, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_12_60913, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_12_60913, 128);
@@ -588,8 +572,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_12_60913, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_12_60913, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_13_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_13_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_13_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_13_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_13_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_13_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_13_59114, 104);
@@ -597,8 +581,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_13_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_13_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_14_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_14_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_14_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_14_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_14_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_14_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_14_59114, 96);
@@ -606,8 +590,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_14_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_14_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_15_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_15_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_15_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_15_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_15_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_15_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_15_59114, 89);
@@ -615,8 +599,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_15_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_15_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_16_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_16_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_16_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_16_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_16_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_16_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_16_59114, 172);
@@ -624,8 +608,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_16_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_16_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_17_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_17_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_17_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_17_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_17_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_17_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_17_59114, 165);
@@ -633,8 +617,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_17_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_17_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_18_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_18_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_18_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_18_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_18_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_18_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_18_59114, 160);
@@ -642,8 +626,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_18_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_18_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_19_61460 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_19_61460, ZSW_LV_IMG_USE(face_goog_19_61460_0));
+    face_goog_19_61460 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_19_61460, ZSW_LV_IMG_USE(face_goog_19_61460_0));
     lv_obj_set_width(face_goog_19_61460, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_19_61460, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_19_61460, 180);
@@ -651,8 +635,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_19_61460, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_19_61460, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_20_61728 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_20_61728, ZSW_LV_IMG_USE(face_goog_20_61728_0));
+    face_goog_20_61728 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_20_61728, ZSW_LV_IMG_USE(face_goog_20_61728_0));
     lv_obj_set_width(face_goog_20_61728, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_20_61728, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_20_61728, 162);
@@ -660,8 +644,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_20_61728, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_20_61728, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_22_72744 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_22_72744, ZSW_LV_IMG_USE(face_goog_22_72744_0));
+    face_goog_22_72744 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_22_72744, ZSW_LV_IMG_USE(face_goog_22_72744_0));
     lv_obj_set_width(face_goog_22_72744, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_22_72744, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_22_72744, 44);
@@ -669,8 +653,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_22_72744, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_22_72744, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_23_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_23_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_23_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_23_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_23_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_23_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_23_59114, 120);
@@ -678,8 +662,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_23_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_23_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_24_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_24_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_24_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_24_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_24_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_24_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_24_59114, 113);
@@ -687,8 +671,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_24_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_24_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_27_87610 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_27_87610, ZSW_LV_IMG_USE(face_goog_27_87610_0));
+    face_goog_27_87610 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_27_87610, ZSW_LV_IMG_USE(face_goog_27_87610_0));
     lv_obj_set_width(face_goog_27_87610, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_27_87610, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_27_87610, 128);
@@ -696,8 +680,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_27_87610, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_27_87610, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_28_97966 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_28_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
+    face_goog_28_97966 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_28_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
     lv_obj_set_width(face_goog_28_97966, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_28_97966, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_28_97966, 74);
@@ -705,8 +689,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_28_97966, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_28_97966, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_29_97966 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_29_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
+    face_goog_29_97966 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_29_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
     lv_obj_set_width(face_goog_29_97966, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_29_97966, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_29_97966, 33);
@@ -714,8 +698,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_29_97966, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_29_97966, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_30_97966 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_30_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
+    face_goog_30_97966 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_30_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
     lv_obj_set_width(face_goog_30_97966, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_30_97966, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_30_97966, 165);
@@ -723,8 +707,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_30_97966, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_30_97966, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_31_97966 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_31_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
+    face_goog_31_97966 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_31_97966, ZSW_LV_IMG_USE(face_goog_28_97966_0));
     lv_obj_set_width(face_goog_31_97966, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_31_97966, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_31_97966, 124);
@@ -732,8 +716,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_31_97966, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_31_97966, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_34_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_34_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_34_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_34_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_34_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_34_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_34_59114, 60);
@@ -741,8 +725,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_34_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_34_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_35_59114 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_35_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
+    face_goog_35_59114 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_35_59114, ZSW_LV_IMG_USE(face_goog_1_59114_0));
     lv_obj_set_width(face_goog_35_59114, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_35_59114, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_35_59114, 52);
@@ -750,8 +734,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_35_59114, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_35_59114, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_36_130812 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_36_130812, ZSW_LV_IMG_USE(face_goog_36_130812_0));
+    face_goog_36_130812 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_36_130812, ZSW_LV_IMG_USE(face_goog_36_130812_0));
     lv_obj_set_width(face_goog_36_130812, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_36_130812, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_36_130812, 67);
@@ -759,8 +743,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_36_130812, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_36_130812, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_37_65535 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_37_65535, ZSW_LV_IMG_USE(face_goog_32_65535_0));
+    face_goog_37_65535 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_37_65535, ZSW_LV_IMG_USE(face_goog_32_65535_0));
     lv_obj_set_width(face_goog_37_65535, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_37_65535, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_37_65535, 46);
@@ -768,8 +752,8 @@ void watchface_goog_show(lv_obj_t *parent, watchface_app_evt_listener evt_cb, zs
     lv_obj_add_flag(face_goog_37_65535, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_clear_flag(face_goog_37_65535, LV_OBJ_FLAG_SCROLLABLE);
 
-    face_goog_41_130994 = lv_img_create(face_goog);
-    lv_img_set_src(face_goog_41_130994, ZSW_LV_IMG_USE(face_goog_41_130994_0));
+    face_goog_41_130994 = lv_image_create(face_goog);
+    lv_image_set_src(face_goog_41_130994, ZSW_LV_IMG_USE(face_goog_41_130994_0));
     lv_obj_set_width(face_goog_41_130994, LV_SIZE_CONTENT);
     lv_obj_set_height(face_goog_41_130994, LV_SIZE_CONTENT);
     lv_obj_set_x(face_goog_41_130994, 50);


### PR DESCRIPTION
Fix for issue #272,  watchface carries the 2nd place over when flipping from 2 digits to 1 digit time when the display is inactive.