### PR TITLE
ci: Allow tests to run on local runner both for internal and PRs from…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
+name: CI
+
 on:
-  pull_request_target:
+  pull_request:  # Internal PRs only
+    types: [opened, synchronize, reopened]
+  pull_request_target:  # External PRs only  
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
@@ -14,4 +18,24 @@ jobs:
 
   test:
     needs: [build]
+    # Dual trigger (pull_request, pull_request_target) approach is needed because:
+    # - Self-hosted runners with hardware are required for testing
+    # - Fork PRs can't access self-hosted runners with 'pull_request' trigger
+    # - Fork PRs need 'pull_request_target' for self-hosted runner access and test annotation.
+    # - Internal PRs need 'pull_request' to test updated workflow files
+    # - Both triggers have comment/annotation permissions in their respective contexts
+    #
+    # Logic ensures each PR type runs the tests exactly once:
+    # - Internal PRs: Only 'pull_request' runs (uses PR branch workflows, no approval needed)
+    # - External PRs: Only 'pull_request_target' runs (uses main branch workflows, requires approval)
+    #
+    # Note: Build job runs twice (once per trigger) but let it be because otherwise
+    # we would need complex cross-workflow artifact downloading logic.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     uses: ./.github/workflows/test.yml
+    with:
+      is-external-pr: ${{ github.event_name == 'pull_request_target' }}
+      pr-head-sha: ${{ github.event.pull_request.head.sha }}
+      pr-head-repo: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,42 @@
-on: [workflow_call]
+on:
+  workflow_call:
+    inputs:
+      is-external-pr:
+        description: 'Whether this is an external PR from a fork'
+        type: boolean
+        required: false
+        default: false
+      pr-head-sha:
+        description: 'PR head SHA for external PRs'
+        type: string
+        required: false
+        default: ''
+      pr-head-repo:
+        description: 'PR head repository for external PRs'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   test:
     runs-on: [self-hosted, x64]
+    environment: ${{ inputs.is-external-pr && 'external-pr-approval' || null }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.is-external-pr && inputs.pr-head-sha || github.sha }}
+          repository: ${{ inputs.is-external-pr && inputs.pr-head-repo || github.repository }}
+
+      - name: PR Type Notice
+        run: |
+          if [ "${{ inputs.is-external-pr }}" = "true" ]; then
+            echo "::notice::External PR detected - using stable workflows from main branch"
+            echo "::notice::Testing code from: ${{ inputs.pr-head-repo }}@${{ inputs.pr-head-sha }}"
+          else
+            echo "::notice::Internal PR detected - using workflows from PR branch"
+          fi
 
       - name: Install dependencies
         continue-on-error: true # JLink install may fail
@@ -138,7 +169,7 @@ jobs:
           require_tests: false # Don't require tests to be found
 
       - name: Create/Update Power Consumption Comment
-        if: github.event_name == 'pull_request_target' && (success() || failure())
+        if: success() || failure()
         continue-on-error: true
         run: |
           source .venv/bin/activate
@@ -153,7 +184,7 @@ jobs:
           fi
 
       - name: Find existing power consumption comment
-        if: github.event_name == 'pull_request_target' && (success() || failure())
+        if: success() || failure()
         uses: peter-evans/find-comment@v3
         id: fc
         with:
@@ -162,7 +193,7 @@ jobs:
           body-includes: '⚡ Power Consumption'
 
       - name: Create or update power consumption comment
-        if: github.event_name == 'pull_request_target' && (success() || failure())
+        if: success() || failure()
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
… forks.

Dual trigger (pull_request, pull_request_target) approach is needed because:
- Self-hosted runners with hardware are required for testing
- Fork PRs can't access self-hosted runners with 'pull_request' trigger
- Fork PRs need 'pull_request_target' for self-hosted runner access and test annotation.
- Internal PRs need 'pull_request' to test updated workflow files
- Both triggers have comment/annotation permissions in their respective contexts

Note: Build job runs twice (once per trigger) but this is acceptable because:
- Build is fast (~2-3 minutes) and uses GitHub-hosted runners (cheap)
- Avoids complex cross-workflow artifact downloading logic
- Each workflow remains self-contained and reliable
- Alternative would require external PRs to download artifacts from pull_request workflow

Logic ensures each PR type runs the tests exactly once:
- Internal PRs: Only 'pull_request' runs (uses PR branch workflows, no approval needed)
- External PRs: Only 'pull_request_target' runs (uses main branch workflows, requires approval)