### PR TITLE
watchdk: Increase drive strength to fix some random i2c issues.

### DIFF
--- a/app/boards/zswatch/watchdk/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/app/boards/zswatch/watchdk/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -34,6 +34,7 @@
         group1 {
             psels = <NRF_PSEL(TWIM_SDA, 0, 27)>,
                     <NRF_PSEL(TWIM_SCL, 0, 25)>;
+            nordic,drive-mode = <NRF_DRIVE_H0D1>;
         };
     };
 


### PR DESCRIPTION
- Helps when connecting external i2c devices with cables which makes the i2c capacitance too high.
- May also fix some WatchDKs that require a battery for RTC to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated I2C1 interface pin drive mode configuration for the watch hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->