### PR TITLE
ble: gadgetbridge: add find device handler

### DIFF
--- a/app/src/ble/gadgetbridge/ble_gadgetbridge.c
+++ b/app/src/ble/gadgetbridge/ble_gadgetbridge.c
@@ -17,8 +17,10 @@
 #include "ble/ble_comm.h"
 #include "ble/ble_log_backend.h"
 #include "ble/ble_transport.h"
+#include "drivers/zsw_vibration_motor.h"
 #include "events/ble_event.h"
 #include "events/music_event.h"
+#include "managers/zsw_power_manager.h"
 #include "managers/zsw_smp_manager.h"
 #include "ble_gadgetbridge.h"
 #include "app_version.h"
@@ -75,6 +77,23 @@ static void on_ble_recording_event(const struct zbus_channel *chan)
     }
 }
 #endif /* CONFIG_APPLICATIONS_USE_VOICE_MEMO */
+
+static void find_dev_work_handler(struct k_work *work)
+{
+    ARG_UNUSED(work);
+    (void)zsw_vibration_run_pattern(ZSW_VIBRATION_PATTERN_FIND);
+    (void)zsw_power_manager_reset_idle_timout();
+}
+
+static K_WORK_DEFINE(find_dev_work, find_dev_work_handler);
+
+static void find_dev_timer_cb(struct k_timer *timer_id)
+{
+    ARG_UNUSED(timer_id);
+    k_work_submit(&find_dev_work);
+}
+
+static K_TIMER_DEFINE(find_dev_timer, find_dev_timer_cb, NULL);
 
 static void send_ble_data_event(struct ble_data_event *evt)
 {
@@ -873,6 +892,43 @@ static int parse_voice_memo_command(char *data, int len)
 #endif /* CONFIG_APPLICATIONS_USE_VOICE_MEMO */
 }
 
+/* {"t":"find","n":true/false} */
+static int parse_find_command(char *data, int len)
+{
+    ARG_UNUSED(len);
+
+    cJSON *root = cJSON_Parse(data);
+    if (root == NULL) {
+        LOG_ERR("Failed to parse find command");
+        return -EINVAL;
+    }
+
+    cJSON *n = cJSON_GetObjectItem(root, "n");
+    if (!cJSON_IsBool(n)) {
+        LOG_WRN("Find command missing 'n'");
+        cJSON_Delete(root);
+        return -EINVAL;
+    }
+
+    bool find = cJSON_IsTrue(n);
+    cJSON_Delete(root);
+
+    if (find) {
+        /* starts the vibration motor and wake display */
+        k_work_submit(&find_dev_work);
+
+        /* Find pattern is 1s, let's trigger the timer slightly longer */
+        k_timer_start(&find_dev_timer, K_MSEC(1100), K_MSEC(1100));
+    } else {
+        k_timer_stop(&find_dev_timer);
+        zsw_vibration_stop();
+    }
+
+    LOG_INF("Find command received, find=%s", find ? "true" : "false");
+
+    return 0;
+}
+
 static int parse_data(char *data, int len)
 {
     int type_len;
@@ -940,6 +996,10 @@ static int parse_data(char *data, int len)
 
     if (strlen("reset") == type_len && strncmp(type, "reset", type_len) == 0) {
         return parse_reset_command(data, len);
+    }
+
+    if (strlen("find") == type_len && strncmp(type, "find", type_len) == 0) {
+        return parse_find_command(data, len);
     }
 
     return 0;

--- a/app/src/drivers/zsw_vibration_motor.c
+++ b/app/src/drivers/zsw_vibration_motor.c
@@ -99,6 +99,17 @@ static vib_motor_state_t quick_rec_error_pattern[] = {
     {.enabled = false, .percent = 0, .delay = 0},
 };
 
+/* Find device: Triple buzz (1s) */
+static vib_motor_state_t find_pattern[] = {
+    {.enabled = true,  .percent = 100, .delay = 80},
+    {.enabled = false, .percent = 0,   .delay = 80},
+    {.enabled = true,  .percent = 100, .delay = 80},
+    {.enabled = false, .percent = 0,   .delay = 80},
+    {.enabled = true,  .percent = 100, .delay = 80},
+    {.enabled = false, .percent = 0,   .delay = 600},
+    {.enabled = false, .percent = 0,   .delay = 0},
+};
+
 static vib_motor_state_t *active_pattern;
 static uint8_t active_pattern_index;
 static uint8_t active_pattern_len;
@@ -148,6 +159,10 @@ int zsw_vibration_run_pattern(zsw_vibration_pattern_t pattern)
             active_pattern = quick_rec_error_pattern;
             active_pattern_len = ARRAY_SIZE(quick_rec_error_pattern);
             break;
+        case ZSW_VIBRATION_PATTERN_FIND:
+            active_pattern = find_pattern;
+            active_pattern_len = ARRAY_SIZE(find_pattern);
+            break;
         default:
             __ASSERT(false, "Invalid vibration pattern");
             return -EINVAL;
@@ -170,6 +185,13 @@ int zsw_vibration_set_enabled(bool enable)
     vib_motor_enabled = enable;
 
     return 0;
+}
+
+void zsw_vibration_stop(void)
+{
+    k_timer_stop(&vibration_timer);
+    vibration_motor_set_on(false);
+    vib_motor_busy = false;
 }
 
 static void run_next_motor_state(vib_motor_state_t *state)

--- a/app/src/drivers/zsw_vibration_motor.h
+++ b/app/src/drivers/zsw_vibration_motor.h
@@ -26,6 +26,7 @@ typedef enum zsw_vibration_pattern {
     ZSW_VIBRATION_PATTERN_QUICK_REC_START,   /* Short-Long: recording started */
     ZSW_VIBRATION_PATTERN_QUICK_REC_STOP,    /* Short-Short: recording stopped */
     ZSW_VIBRATION_PATTERN_QUICK_REC_ERROR,   /* Long-Long: recording error */
+    ZSW_VIBRATION_PATTERN_FIND,              /* Triple buzz: find device */
 } zsw_vibration_pattern_t;
 
 /*
@@ -38,6 +39,14 @@ typedef enum zsw_vibration_pattern {
 * @return 0 on success, negative error code on failure
 */
 int zsw_vibration_run_pattern(zsw_vibration_pattern_t pattern);
+
+/*
+ * @brief Stop any ongoing vibration pattern
+ *
+ * @details This can be used to stop an ongoing pattern, for example when
+ * a timer alarm is dismissed.
+*/
+void zsw_vibration_stop(void);
 
 /*
 * @brief Enable or disable the vibration motor


### PR DESCRIPTION
Issue #537 

Parse find device message and trigger vibration motor and wake the display until `{"t":"find","n":false}` is received.

Note:
The current vibration motor doesn't have a stop function. I was thinking if it was a good idea to add it, then I saw this [line](https://github.com/ZSWatch/ZSWatch/blob/90df2bf3225b459950c1eea55e84888866a3b886/app/src/applications/timer/timer_app.c#L88) in the `timer_app.c`. Perhaps the `zsw_vibration_stop` function is the right addition so that the timer app could build on top of it if that TODO is ever implemented?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote "Find Device" via Bluetooth: triggers a distinctive triple-buzz vibration to locate your smartwatch and can be toggled on/off.
  * Added a command to immediately stop active vibrations.

* **Improvements**
  * More reliable handling of incoming find commands to avoid unintended behavior from malformed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->