### PR TITLE
Add option to run vibration pattern in a loop

### DIFF
--- a/app/src/applications/timer/timer_app.c
+++ b/app/src/applications/timer/timer_app.c
@@ -61,6 +61,12 @@ static void timer_app_stop(void)
     zsw_periodic_chan_rm_obs(&periodic_event_1s_chan, &timer_app_1s_event_listener);
 }
 
+static void on_close_timer_cb(bool yes_pressed)
+{
+    ARG_UNUSED(yes_pressed);
+    zsw_vibration_stop();
+}
+
 static void alarm_triggered_cb(void *user_data)
 {
     // TODO also check:
@@ -84,9 +90,9 @@ static void alarm_triggered_cb(void *user_data)
     static char buf[50];
     snprintf(buf, sizeof(buf), "Timer %d triggered", timer_id);
 
-    zsw_vibration_run_pattern(ZSW_VIBRATION_PATTERN_ALARM);
-    // TODO: Make a different popup for timer, and make it vibrate until timer is dismissed
-    zsw_popup_show("Timer", buf, NULL, 10, false);
+    /* Run pattern until pop up is dismissed or timeout */
+    zsw_vibration_run_pattern_loop(ZSW_VIBRATION_PATTERN_ALARM);
+    zsw_popup_show("Timer", buf, on_close_timer_cb, 30, false);
 }
 
 static int find_free_timer_slot(void)

--- a/app/src/ble/gadgetbridge/ble_gadgetbridge.c
+++ b/app/src/ble/gadgetbridge/ble_gadgetbridge.c
@@ -81,7 +81,6 @@ static void on_ble_recording_event(const struct zbus_channel *chan)
 static void find_dev_work_handler(struct k_work *work)
 {
     ARG_UNUSED(work);
-    (void)zsw_vibration_run_pattern(ZSW_VIBRATION_PATTERN_FIND);
     (void)zsw_power_manager_reset_idle_timout();
 }
 
@@ -915,6 +914,7 @@ static int parse_find_command(char *data, int len)
 
     if (find) {
         /* starts the vibration motor and wake display */
+        (void)zsw_vibration_run_pattern_loop(ZSW_VIBRATION_PATTERN_FIND);
         k_work_submit(&find_dev_work);
 
         /* Find pattern is 1s, let's trigger the timer slightly longer */

--- a/app/src/drivers/zsw_vibration_motor.c
+++ b/app/src/drivers/zsw_vibration_motor.c
@@ -115,6 +115,7 @@ static uint8_t active_pattern_index;
 static uint8_t active_pattern_len;
 static bool vib_motor_busy;
 static bool vib_motor_enabled;
+static bool repeat_pattern = false;
 
 int zsw_vibration_run_pattern(zsw_vibration_pattern_t pattern)
 {
@@ -171,8 +172,20 @@ int zsw_vibration_run_pattern(zsw_vibration_pattern_t pattern)
 
     vib_motor_busy = true;
     active_pattern_index = 0;
+    repeat_pattern = false;
     run_next_motor_state(&active_pattern[active_pattern_index]);
 
+    return 0;
+}
+
+int zsw_vibration_run_pattern_loop(zsw_vibration_pattern_t pattern)
+{
+    int ret = zsw_vibration_run_pattern(pattern);
+    if (ret != 0) {
+        return ret;
+    }
+
+    repeat_pattern = true;
     return 0;
 }
 
@@ -192,6 +205,7 @@ void zsw_vibration_stop(void)
     k_timer_stop(&vibration_timer);
     vibration_motor_set_on(false);
     vib_motor_busy = false;
+    repeat_pattern = false;
 }
 
 static void run_next_motor_state(vib_motor_state_t *state)
@@ -226,12 +240,18 @@ static void vibration_motor_set_on(bool on)
 static void pattern_timer_timeout(struct k_timer *timer_id)
 {
     active_pattern_index++;
-    if (active_pattern_index < active_pattern_len) {
-        run_next_motor_state(&active_pattern[active_pattern_index]);
-    } else {
-        // Pattern done
-        vib_motor_busy = false;
+
+    if (active_pattern_index >= active_pattern_len) {
+        /* If not repeat, then pattern is done */
+        if (!repeat_pattern) {
+            vib_motor_busy = false;
+            return;
+        }
+
+        active_pattern_index = 0;
     }
+
+    run_next_motor_state(&active_pattern[active_pattern_index]);
 }
 
 static int vibration_motor_init(void)

--- a/app/src/drivers/zsw_vibration_motor.h
+++ b/app/src/drivers/zsw_vibration_motor.h
@@ -33,12 +33,24 @@ typedef enum zsw_vibration_pattern {
 * @brief Run a vibration pattern
 *
 * @details Run a vibration pattern, the pattern will run asynchronously and
-* any try to run a pattern while another is running will resutlt in -EBUSY.
+* any try to run a pattern while another is running will result in -EBUSY.
 *
 * @param pattern The pattern to run
 * @return 0 on success, negative error code on failure
 */
 int zsw_vibration_run_pattern(zsw_vibration_pattern_t pattern);
+
+/*
+ * @brief Run a vibration pattern in loop
+ *
+ * @details Run a vibration pattern in a loop until @ref zsw_vibration_stop is called,
+ * the pattern will run asynchronously and any try to run a pattern while another
+ * is running will result in -EBUSY.
+ *
+ * @param pattern The pattern to run
+ * @return 0 on success, negative error code on failure
+ */
+int zsw_vibration_run_pattern_loop(zsw_vibration_pattern_t pattern);
 
 /*
  * @brief Stop any ongoing vibration pattern


### PR DESCRIPTION
Some minor addition to the vibration motor:
- Add a function to run the vibration pattern in a loop untili stopped.
- Update the find device handler (in `ble_gadgetbridge.c`) and timer app to use the loop pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timer alerts now vibrate continuously with a looping pattern until the notification is dismissed
  * Find device command triggers sustained vibration feedback
  * Enhanced vibration motor support for repeating patterns

* **Bug Fixes**
  * Fixed documentation typo in vibration driver

<!-- end of auto-generated comment: release notes by coderabbit.ai -->