### PR TITLE
Add setting to navigate the watch without physical buttons. Swipe dow…

### DIFF
--- a/app/src/applications/settings/settings_app.c
+++ b/app/src/applications/settings/settings_app.c
@@ -30,6 +30,7 @@
 #include "sensors/zsw_imu.h"
 #include "drivers/zsw_display_control.h"
 #include "managers/zsw_app_manager.h"
+#include "ui/zsw_ui_controller.h"
 #include "zsw_settings.h"
 #include <filesystem/zsw_rtt_flash_loader.h>
 #include "ui/popup/zsw_popup_window.h"
@@ -55,6 +56,7 @@ static void on_clear_external_flash_changed(lv_setting_value_t value, bool final
 static void on_factory_reset_changed(lv_setting_value_t value, bool final);
 static void on_ble_log_changed(lv_setting_value_t value, bool final);
 static void on_reboot_changed(lv_setting_value_t value, bool final);
+static void on_swipe_back_changed(lv_setting_value_t value, bool final);
 static void on_watchface_animation_changed(lv_setting_value_t value, bool final);
 static void on_watchface_tick_interval_changed(lv_setting_value_t value, bool final);
 
@@ -66,6 +68,7 @@ typedef struct setting_app {
     zsw_settings_brightness_t           brightness;
     zsw_settings_vib_on_press_t         vibration_on_click;
     zsw_settings_display_always_on_t    display_always_on;
+    zsw_settings_swipe_back_t           swipe_back_enabled;
     zsw_settings_ble_log_en_t           ble_log_enabled;
     zsw_settings_ble_aoa_en_t           ble_aoa_enabled;
     zsw_settings_ble_aoa_int_t          ble_aoa_tx_interval;
@@ -79,6 +82,7 @@ static setting_app_t settings_app = {
     .brightness = 50,
     .vibration_on_click = true,
     .display_always_on = false,
+    .swipe_back_enabled = false,
     .ble_log_enabled = false,
     .ble_aoa_enabled = false,
     .ble_aoa_tx_interval = 100,
@@ -182,6 +186,17 @@ static lv_settings_item_t general_page_items[] = {
             .sw = {
                 .name = "Vibrate on click",
                 .inital_val = &settings_app.vibration_on_click,
+            }
+        }
+    },
+    {
+        .type = LV_SETTINGS_TYPE_SWITCH,
+        .icon = LV_SYMBOL_LEFT,
+        .change_callback = on_swipe_back_changed,
+        .item = {
+            .sw = {
+                .name = "Swipe up to go back",
+                .inital_val = &settings_app.swipe_back_enabled,
             }
         }
     },
@@ -361,6 +376,15 @@ static void on_display_vib_press_changed(lv_setting_value_t value, bool final)
                       sizeof(settings_app.vibration_on_click));
 }
 
+static void on_swipe_back_changed(lv_setting_value_t value, bool final)
+{
+    settings_app.swipe_back_enabled = value.item.sw;
+    LOG_INF("Swipe-back setting changed: %d final=%d", settings_app.swipe_back_enabled, final);
+    zsw_ui_controller_set_swipe_back_enabled(settings_app.swipe_back_enabled);
+    settings_save_one(ZSW_SETTINGS_SWIPE_BACK, &settings_app.swipe_back_enabled,
+                      sizeof(settings_app.swipe_back_enabled));
+}
+
 static void on_ble_log_changed(lv_setting_value_t value, bool final)
 {
     settings_app.ble_log_enabled = value.item.sw;
@@ -532,6 +556,17 @@ static int settings_load_cb(const char *name, size_t len,
         }
 
         rc = read_cb(cb_arg, &settings_app.display_always_on, sizeof(settings_app.display_always_on));
+        if (rc >= 0) {
+            return 0;
+        }
+        return rc;
+    }
+    if (settings_name_steq(name, ZSW_SETTINGS_KEY_SWIPE_BACK, &next) && !next) {
+        if (len != sizeof(settings_app.swipe_back_enabled)) {
+            return -EINVAL;
+        }
+
+        rc = read_cb(cb_arg, &settings_app.swipe_back_enabled, sizeof(settings_app.swipe_back_enabled));
         if (rc >= 0) {
             return 0;
         }

--- a/app/src/ui/app_picker/app_picker_ui.c
+++ b/app/src/ui/app_picker/app_picker_ui.c
@@ -57,6 +57,7 @@ typedef struct {
 static const zsw_app_folder_info_t *folder_info;
 
 static lv_obj_t *picker_root;
+static lv_obj_t *gesture_root;
 static app_picker_on_app_selected_cb app_selected_cb;
 static int current_page;
 static int total_pages;
@@ -478,6 +479,7 @@ lv_obj_t *app_picker_ui_create(lv_obj_t *root, lv_group_t *group,
 
     cache_object_references();
 
+    gesture_root = root;
     lv_obj_add_event_cb(root, on_swipe_event, LV_EVENT_GESTURE, NULL);
 
     if (nav_left) {
@@ -511,6 +513,11 @@ void app_picker_ui_delete(void)
     /* Save state before deleting */
     last_page = current_page;
     last_folder = open_folder;
+
+    if (gesture_root && lv_obj_is_valid(gesture_root)) {
+        lv_obj_remove_event_cb(gesture_root, on_swipe_event);
+    }
+    gesture_root = NULL;
 
     if (picker_root) {
         lv_obj_del(picker_root);

--- a/app/src/ui/zsw_ui_controller.c
+++ b/app/src/ui/zsw_ui_controller.c
@@ -71,18 +71,52 @@ static lv_obj_t *root_screen;
 static lv_group_t *input_group;
 static lv_group_t *temp_group;
 static lv_indev_t *enc_indev;
+static lv_indev_t *touch_indev;
 static uint8_t last_pressed;
 static ui_state_t watch_state = INIT_STATE;
+static bool swipe_back_enabled;
 
 static void encoder_read(lv_indev_t *indev, lv_indev_data_t *data);
 static void on_input_subsys_callback(struct input_event *evt, void *user_data);
 static void on_watchface_app_event_callback(watchface_app_evt_t evt);
+static void on_root_screen_gesture(lv_event_t *e);
 static void async_turn_off_buttons_allocation(void *unused);
 static void open_application_manager_page(void *app_name);
 static void on_application_manager_close(void);
 static void on_onboarding_done(void);
+static bool handle_back_action(void);
+static int settings_load_handler_swipe_back(const char *key, size_t len,
+                                            settings_read_cb read_cb,
+                                            void *cb_arg, void *param);
 
 LOG_MODULE_REGISTER(zsw_ui_controller, CONFIG_ZSW_UI_CONTROLLER_LOG_LEVEL);
+
+static bool handle_back_action(void)
+{
+#ifdef CONFIG_APPLICATIONS_USE_VOICE_MEMO
+    if (zsw_recording_overlay_is_shown()) {
+        zsw_recording_manager_stop();
+        zsw_recording_overlay_hide();
+        return true;
+    }
+
+    if (zsw_voice_memo_popup_is_shown()) {
+        return true;
+    }
+#endif
+
+    if (zsw_notification_popup_is_shown()) {
+        zsw_notification_popup_remove();
+        return true;
+    }
+
+    if (watch_state == APPLICATION_MANAGER_STATE) {
+        zsw_app_manager_exit_app();
+        return true;
+    }
+
+    return false;
+}
 
 static void run_input_work(struct k_work *item)
 {
@@ -108,21 +142,7 @@ static void run_input_work(struct k_work *item)
                 break;
             }
             case INPUT_KEY_3: {
-#ifdef CONFIG_APPLICATIONS_USE_VOICE_MEMO
-                if (zsw_recording_overlay_is_shown()) {
-                    zsw_recording_manager_stop();
-                    zsw_recording_overlay_hide();
-                    break;
-                }
-                if (zsw_voice_memo_popup_is_shown()) {
-                    break;
-                }
-#endif
-                if (zsw_notification_popup_is_shown()) {
-                    zsw_notification_popup_remove();
-                } else if (watch_state == APPLICATION_MANAGER_STATE) {
-                    zsw_app_manager_exit_app();
-
+                if (handle_back_action()) {
                     return;
                 }
 
@@ -164,6 +184,11 @@ static void open_application_manager_page(void *app_name)
     zsw_app_manager_show(on_application_manager_close, root_screen, input_group, (char *)app_name);
 }
 
+void zsw_ui_controller_set_swipe_back_enabled(bool enabled)
+{
+    swipe_back_enabled = enabled;
+}
+
 void zsw_ui_controller_set_notification_mode(void)
 {
     lv_group_set_default(temp_group);
@@ -193,6 +218,29 @@ static void on_application_manager_close(void)
 static void async_turn_off_buttons_allocation(void *unused)
 {
     is_buttons_for_lvgl = false;
+}
+
+static void on_root_screen_gesture(lv_event_t *e)
+{
+    lv_indev_t *indev = lv_indev_active();
+
+    if (lv_event_get_code(e) != LV_EVENT_GESTURE || indev == NULL) {
+        return;
+    }
+
+    lv_dir_t dir = lv_indev_get_gesture_dir(indev);
+
+    if (!swipe_back_enabled) {
+        return;
+    }
+
+    if (dir != LV_DIR_TOP) {
+        return;
+    }
+
+    if (handle_back_action()) {
+        lv_indev_wait_release(indev);
+    }
 }
 
 static void on_input_subsys_callback(struct input_event *evt, void *user_data)
@@ -398,14 +446,29 @@ static int settings_load_handler_onboarding(const char *key, size_t len,
     return 0;
 }
 
+static int settings_load_handler_swipe_back(const char *key, size_t len,
+                                            settings_read_cb read_cb,
+                                            void *cb_arg, void *param)
+{
+    if (len != sizeof(zsw_settings_swipe_back_t)) {
+        return -EINVAL;
+    }
+
+    int rc = read_cb(cb_arg, param, sizeof(zsw_settings_swipe_back_t));
+    if (rc < 0) {
+        return rc;
+    }
+
+    return 0;
+}
+
 int zsw_ui_controller_init(void)
 {
-    lv_indev_t *touch_indev;
-
     // Initialize LVGL Editor subjects and assets
     lvgl_editor_init_gen("");
 
     root_screen = lv_scr_act();
+    lv_obj_add_event_cb(root_screen, on_root_screen_gesture, LV_EVENT_GESTURE, NULL);
 
     lv_obj_set_style_bg_color(root_screen, zsw_color_dark_gray(), LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -437,13 +500,22 @@ int zsw_ui_controller_init(void)
     }
 
     zsw_settings_onboarding_done_t onboarding_done = false;
+    swipe_back_enabled = false;
+    int err = settings_load_subtree_direct(ZSW_SETTINGS_SWIPE_BACK,
+                                           settings_load_handler_swipe_back,
+                                           &swipe_back_enabled);
+    if (err != 0) {
+        LOG_WRN("Failed to load swipe-back setting, defaulting disabled");
+    } else {
+        LOG_INF("Swipe-back setting loaded: %d", swipe_back_enabled);
+    }
 #ifdef CONFIG_ZSW_TEST_SKIP_ONBOARDING
     onboarding_done = true;
     LOG_INF("Test mode: skipping onboarding");
 #else
-    int err = settings_load_subtree_direct(ZSW_SETTINGS_ONBOARDING_DONE,
-                                           settings_load_handler_onboarding,
-                                           &onboarding_done);
+    err = settings_load_subtree_direct(ZSW_SETTINGS_ONBOARDING_DONE,
+                                       settings_load_handler_onboarding,
+                                       &onboarding_done);
     if (err != 0) {
         LOG_WRN("Failed to load onboarding setting, assuming first boot");
     }

--- a/app/src/ui/zsw_ui_controller.h
+++ b/app/src/ui/zsw_ui_controller.h
@@ -18,6 +18,8 @@
 #ifndef ZSW_UI_CONTROLLER_H
 #define ZSW_UI_CONTROLLER_H
 
+#include <stdbool.h>
+
 /**
  * @brief Initialize the UI controller system
  *
@@ -57,6 +59,9 @@ void zsw_ui_controller_set_notification_mode(void);
  * This returns input handling to the appropriate state based on current UI mode.
  */
 void zsw_ui_controller_clear_notification_mode(void);
+
+/** @brief Enable or disable swipe-up back navigation at runtime. */
+void zsw_ui_controller_set_swipe_back_enabled(bool enabled);
 
 typedef enum {
     ZSW_UI_STATE_INIT = 0,

--- a/app/src/zsw_settings.h
+++ b/app/src/zsw_settings.h
@@ -58,4 +58,8 @@ typedef bool zsw_settings_onboarding_done_t;
 #define ZSW_SETTINGS_KEY_ONBOARDING_DONE "onboard"
 #define ZSW_SETTINGS_ONBOARDING_DONE (ZSW_SETTINGS_PATH "/" ZSW_SETTINGS_KEY_ONBOARDING_DONE)
 
+typedef bool zsw_settings_swipe_back_t;
+#define ZSW_SETTINGS_KEY_SWIPE_BACK "swipe_back"
+#define ZSW_SETTINGS_SWIPE_BACK (ZSW_SETTINGS_PATH "/" ZSW_SETTINGS_KEY_SWIPE_BACK)
+
 int zsw_settings_erase_all(void);


### PR DESCRIPTION
…n => back.


Some TODO issues still:
- Apps that are full screen scrollable list are hard to exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Swipe up to go back" toggle in Settings with persistent storage.
  * Global swipe-up gesture on the home/root screen can trigger back navigation when enabled.

* **Bug Fixes**
  * Improved gesture handling: picker teardown now reliably detaches gesture handlers.
  * Back action now consistently closes overlays/popups or exits the app manager before navigating back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->