### PR TITLE
Keep timer popup visible until dismissed

### DIFF
--- a/app/src/applications/timer/timer_app.c
+++ b/app/src/applications/timer/timer_app.c
@@ -91,9 +91,9 @@ static void alarm_triggered_cb(void *user_data)
     snprintf(buf, sizeof(buf), "Timer %d is up!", timer_id);
 
     /* Run pattern until popup is dismissed. */
-    zsw_vibration_run_pattern_loop(ZSW_VIBRATION_PATTERN_ALARM);
-    zsw_timer_popup_show("Timer", buf, on_close_timer_cb);
-
+    if (zsw_timer_popup_show("Timer", buf, on_close_timer_cb)) {
+       zsw_vibration_run_pattern_loop(ZSW_VIBRATION_PATTERN_ALARM);
+    }
 
 
 }

--- a/app/src/applications/timer/timer_app.c
+++ b/app/src/applications/timer/timer_app.c
@@ -88,11 +88,14 @@ static void alarm_triggered_cb(void *user_data)
     }
 
     static char buf[50];
-    snprintf(buf, sizeof(buf), "Timer %d triggered", timer_id);
+    snprintf(buf, sizeof(buf), "Timer %d is up!", timer_id);
 
-    /* Run pattern until pop up is dismissed or timeout */
+    /* Run pattern until popup is dismissed. */
     zsw_vibration_run_pattern_loop(ZSW_VIBRATION_PATTERN_ALARM);
-    zsw_popup_show("Timer", buf, on_close_timer_cb, 30, false);
+    zsw_timer_popup_show("Timer", buf, on_close_timer_cb);
+
+
+
 }
 
 static int find_free_timer_slot(void)

--- a/app/src/ui/popup/zsw_popup_window.c
+++ b/app/src/ui/popup/zsw_popup_window.c
@@ -21,12 +21,56 @@
 static void on_popup_button_pressed(lv_event_t *e);
 static void on_popup_close_button_pressed(lv_event_t *e);
 static void close_popup_timer(lv_timer_t *timer);
+static void on_timer_popup_dismiss_pressed(lv_event_t *e);
 
 static lv_obj_t *mbox;
 static lv_obj_t *yes_btn;
 static lv_obj_t *no_btn;
 static on_close_popup_cb_t on_close_cb;
 static lv_timer_t *auto_close_timer;
+
+void zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t close_cb)
+{
+    if (mbox) {
+    // TODO handle queue of popups
+        return;
+    }
+
+    zsw_power_manager_reset_idle_timout();
+    on_close_cb = close_cb;
+    auto_close_timer = NULL;
+
+    mbox = lv_msgbox_create(lv_layer_top());
+    lv_msgbox_add_title(mbox, title);
+    lv_msgbox_add_text(mbox, body);
+
+    lv_obj_t *dismiss_btn =
+        lv_msgbox_add_footer_button(mbox, "Dismiss");
+
+    lv_obj_add_event_cb(dismiss_btn, on_timer_popup_dismiss_pressed, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_set_scrollbar_mode(lv_layer_top(), LV_SCROLLBAR_MODE_OFF);
+    lv_obj_set_scrollbar_mode(mbox, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_center(mbox);
+
+    lv_group_focus_obj(dismiss_btn);
+
+    lv_obj_set_size(mbox, 180, LV_SIZE_CONTENT);
+    lv_obj_set_style_radius(mbox, 5, 0);
+    lv_obj_clear_flag(mbox, LV_OBJ_FLAG_SCROLLABLE);
+
+    static lv_style_t style_indic_not_bg;
+    lv_style_init(&style_indic_not_bg);
+    lv_style_set_bg_color(&style_indic_not_bg, lv_color_hex(0x2C3333));
+    lv_obj_add_style(mbox, &style_indic_not_bg, 0);
+
+    static lv_style_t color_style;
+    lv_style_init(&color_style);
+    lv_style_set_text_color(&color_style, lv_color_hex(0xCBE4DE));
+    lv_style_set_bg_color(&color_style, lv_color_hex(0x2C3333));
+    lv_obj_add_style(dismiss_btn, &color_style, 0);
+}
+
 
 void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
                     bool display_yes_no)
@@ -79,14 +123,32 @@ void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint3
     lv_timer_set_repeat_count(auto_close_timer, 1);
 }
 
+
 void zsw_popup_remove(void)
 {
     if (mbox) {
-        lv_timer_del(auto_close_timer);
+        if (auto_close_timer) {
+            lv_timer_del(auto_close_timer);
+            auto_close_timer = NULL;
+        }
+
         lv_msgbox_close(mbox);
         mbox = NULL;
     }
 }
+
+
+static void on_timer_popup_dismiss_pressed(lv_event_t *e)
+{
+    ARG_UNUSED(e);
+
+    zsw_popup_remove();
+
+    if (on_close_cb) {
+        on_close_cb(true);
+    }
+}
+
 
 static void on_popup_button_pressed(lv_event_t *e)
 {

--- a/app/src/ui/popup/zsw_popup_window.c
+++ b/app/src/ui/popup/zsw_popup_window.c
@@ -29,11 +29,11 @@ static lv_obj_t *no_btn;
 static on_close_popup_cb_t on_close_cb;
 static lv_timer_t *auto_close_timer;
 
-void zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t close_cb)
+bool zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t close_cb)
 {
     if (mbox) {
     // TODO handle queue of popups
-        return;
+        return false;
     }
 
     zsw_power_manager_reset_idle_timout();
@@ -69,6 +69,9 @@ void zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t close_cb)
     lv_style_set_text_color(&color_style, lv_color_hex(0xCBE4DE));
     lv_style_set_bg_color(&color_style, lv_color_hex(0x2C3333));
     lv_obj_add_style(dismiss_btn, &color_style, 0);
+
+    return true;
+
 }
 
 

--- a/app/src/ui/popup/zsw_popup_window.h
+++ b/app/src/ui/popup/zsw_popup_window.h
@@ -21,6 +21,9 @@
 
 typedef void(*on_close_popup_cb_t)(bool confirmed);
 
+void zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t dismiss_cb);
+
 void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
                     bool display_yes_no);
+
 void zsw_popup_remove(void);

--- a/app/src/ui/popup/zsw_popup_window.h
+++ b/app/src/ui/popup/zsw_popup_window.h
@@ -21,7 +21,7 @@
 
 typedef void(*on_close_popup_cb_t)(bool confirmed);
 
-void zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t dismiss_cb);
+bool zsw_timer_popup_show(char *title, char *body, on_close_popup_cb_t dismiss_cb);
 
 void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
                     bool display_yes_no);


### PR DESCRIPTION
# Summary
- Added a dedicated timer popup with a dismiss button.
- Timer vibration now continues until the popup is dismissed. (note: not tested on hardware)
- Also changed message 'timer triggered' to 'timer is up' as I feel this is a more accurate behaviour description for the user
- Subsequent popup functionality has been tested as follows:

# Testing
Normal (ie non timer) popup still auto-closes correctly via dummy popup (see screenshot)

<img width="1026" height="272" alt="zsw test image" src="https://github.com/user-attachments/assets/c177adf7-62fc-4dd9-a946-415296c6e25e" />

Also tested:
- Timer popup dismisses correctly
- Triggered timer popup twice in a row.
- Triggered a normal popup after a timer popup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timer alerts now show "Timer X is up!" in a popup with a dedicated Dismiss button.
  * Vibration for timer alerts runs while the popup is shown and stops on dismissal.

* **Bug Fixes**
  * Improved cleanup of timer-related UI so stale auto-close timers and lingering notifications are prevented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZSWatch/ZSWatch/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->