### PR TITLE
Feature/improve compass calibration clean

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -28,6 +28,7 @@ add_subdirectory(src/images)
 add_subdirectory(src/ui)
 add_subdirectory(lvgl_editor)
 
+
 include_directories(src/)
 include_directories(src/codec)
 include_directories(src/ui)
@@ -38,6 +39,23 @@ include_directories(src/drivers)
 include_directories(src/sensors)
 include_directories(src/sensor_fusion)
 include_directories(src/ble)
+
+#
+# Magnetometer calibration library
+#
+
+
+FILE(GLOB mag_calib_sources
+    src/ext/magnetometer_calibration/*.c
+)
+
+target_sources(app PRIVATE ${mag_calib_sources})
+
+target_include_directories(app PRIVATE
+    src/ext/magnetometer_calibration
+)
+
+
 
 if(CONFIG_AUDIO_DMIC)
 set(kissfft_sources

--- a/app/src/applications/compass/compass_app.c
+++ b/app/src/applications/compass/compass_app.c
@@ -53,14 +53,16 @@ static void compass_app_start(lv_obj_t *root, lv_group_t *group)
     compass_ui_show(root, on_start_calibration);
 
     if (zsw_magnetometer_recalibration_required()) {
-    zsw_popup_show("Calibration",
-                 "Compass calibration format changed. Please recalibrate.",
-                 NULL,
-                 5,
-                 false);
+        zsw_popup_show("Calibration",
+                       "Compass calibration format changed. Please recalibrate.",
+                       NULL,
+                       5,
+                       false);
     }
 
-    refresh_timer = lv_timer_create(timer_callback, CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_REFRESH_INTERVAL_MS,  NULL);
+    refresh_timer = lv_timer_create(timer_callback,
+                                    CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_REFRESH_INTERVAL_MS,
+                                    NULL);
     zsw_sensor_fusion_init();
 }
 
@@ -70,22 +72,22 @@ static void compass_app_stop(void)
         lv_timer_del(refresh_timer);
         refresh_timer = NULL;
     }
-    compass_ui_remove();
-    zsw_sensor_fusion_deinit();
 
     if (getting_data) {
-      getting_data = false;
-      zsw_magnetometer_cancel_calibration();
-      zsw_popup_remove();
-}
-}
+        getting_data = false;
+        zsw_magnetometer_cancel_calibration();
+        zsw_popup_remove();
+    }
 
+    compass_ui_remove();
+    zsw_sensor_fusion_deinit();
+}
 
 static void on_start_calibration(void)
 {
-      if (getting_data) {
-      return;
-      }
+    if (getting_data) {
+        return;
+    }
 
     zsw_popup_remove();
 
@@ -102,9 +104,7 @@ static void on_start_calibration(void)
     getting_data = true;
     cal_start_ms = lv_tick_get();
     compass_ui_show_calibration();
-
 }
-
 
 static void timer_callback(lv_timer_t *timer)
 {
@@ -112,7 +112,6 @@ static void timer_callback(lv_timer_t *timer)
     bool app_visible = app.current_state == ZSW_APP_STATE_UI_VISIBLE;
 
     if (getting_data && app_visible) {
-
         int px;
         int py;
         int pz;
@@ -120,12 +119,9 @@ static void timer_callback(lv_timer_t *timer)
         if (zsw_magnetometer_get_calibration_progress(&px, &py, &pz) == 0) {
             compass_ui_set_calibration_progress(px, py, pz);
         }
-
     }
 
-    if (getting_data &&
-        zsw_magnetometer_calibration_ready()) {
-
+    if (getting_data && zsw_magnetometer_calibration_ready()) {
         int ret = zsw_magnetometer_compute_compensation();
 
         getting_data = false;
@@ -141,11 +137,7 @@ static void timer_callback(lv_timer_t *timer)
         }
 
         return;
-
-
-
-        }
-
+    }
 
     if (getting_data &&
         lv_tick_elaps(cal_start_ms) >=
@@ -154,16 +146,14 @@ static void timer_callback(lv_timer_t *timer)
         zsw_magnetometer_cancel_calibration();
 
         if (app_visible) {
-          compass_ui_hide_calibration();
-          zsw_popup_show("Calibration", "Calibration time out", NULL, 3, false);
-          }
+            compass_ui_hide_calibration();
+            zsw_popup_show("Calibration", "Calibration time out", NULL, 3, false);
+        }
 
-          return;
+        return;
+    }
 
-          }
-
-
-    if (!getting_data && app_visible) {  //heading refresh when not calibrating
+    if (!getting_data && app_visible) {
         zsw_sensor_fusion_get_heading(&heading);
         compass_ui_set_heading(heading);
     }

--- a/app/src/applications/compass/compass_app.c
+++ b/app/src/applications/compass/compass_app.c
@@ -26,6 +26,7 @@
 #include "sensor_fusion/zsw_sensor_fusion.h"
 #include "ui/utils/zsw_ui_utils.h"
 
+
 LOG_MODULE_REGISTER(compass_app, LOG_LEVEL_DBG);
 
 // Functions needed for all applications
@@ -47,8 +48,15 @@ static application_t app = {
 };
 
 static lv_timer_t *refresh_timer;
-static bool is_calibrating;
+static bool getting_data;
 static uint32_t cal_start_ms;
+
+#define CONFIG_BOARD_NATIVE_SIM
+
+
+#ifdef CONFIG_BOARD_NATIVE_SIM
+static int p; //track dummy progress
+#endif
 
 static void compass_app_start(lv_obj_t *root, lv_group_t *group)
 {
@@ -57,39 +65,108 @@ static void compass_app_start(lv_obj_t *root, lv_group_t *group)
     zsw_sensor_fusion_init();
 }
 
-static void compass_app_stop(void)
+static void compass_app_stop(void) //app lifecycle callback that runs when the Compass app is closed or switched away from
 {
     if (refresh_timer) {
         lv_timer_del(refresh_timer);
+        refresh_timer = NULL;
     }
     compass_ui_remove();
-    zsw_magnetometer_stop_calibration();
     zsw_sensor_fusion_deinit();
-    if (is_calibrating) {
+
+    if (getting_data) {
+        getting_data = false;
         zsw_popup_remove();
+
     }
 }
+
 
 static void on_start_calibration(void)
 {
-    zsw_magnetometer_start_calibration();
-    is_calibrating = true;
+      if (getting_data) {
+      return;
+      }
+
+    zsw_popup_remove();
+
+    zsw_magnetometer_gather_data();
+
+    #ifdef CONFIG_BOARD_NATIVE_SIM
+    p = 0;
+    #endif
+
+    getting_data = true;
     cal_start_ms = lv_tick_get();
-    zsw_popup_show("Calibration",
-                   "Rotate the watch 360 degrees\naround each x,y,z.\n a few times.", NULL,
-                   CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_CALIBRATION_TIME_S, false);
+    compass_ui_show_calibration();
+
 }
 
-static void timer_callback(lv_timer_t *timer)
+
+// Now used for:
+//1. Calibration data gathering timeout failure - progress bars decide success; timer only catches timeout.
+//2. heading refresh when not calibrating (as before)
+
+static void timer_callback(lv_timer_t *timer) //runs every however many milliseconds
 {
     float heading;
-    if (is_calibrating &&
-        (lv_tick_elaps(cal_start_ms) >= (CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_CALIBRATION_TIME_S * 1000UL))) {
-        zsw_magnetometer_stop_calibration();
-        is_calibrating = false;
-        zsw_popup_remove();
+
+    #ifdef CONFIG_BOARD_NATIVE_SIM
+    if (getting_data) {
+
+        p += 5;
+        //if //(p > 100) {
+            //p = 100;
+        //}
+
+
+        compass_ui_set_calibration_progress(p, p, p);
     }
-    if (!is_calibrating) {
+    #endif
+
+
+    //when we have enough data and we can try the calc the compensation
+    if (getting_data &&
+        zsw_magnetometer_calibration_ready()) { //ie we have enough data
+
+        int ret = zsw_magnetometer_compute_compensation();  //try to compute offsets
+
+        getting_data = false;
+        compass_ui_hide_calibration();
+
+        if (ret == 0) {
+            zsw_popup_show("Calibration",
+                           "Calibration successful",
+                           NULL,
+                           3,
+                           false);
+        } else {
+            zsw_popup_show("Calibration",
+                           "Calibration failed",
+                           NULL,
+                           3,
+                           false);
+        }
+
+        return;
+    }
+
+
+    if (getting_data && //time is up
+        lv_tick_elaps(cal_start_ms) >=
+        (CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_CALIBRATION_TIME_S * 1000UL)) {
+        getting_data = false;
+        compass_ui_hide_calibration();
+
+        zsw_popup_show("Calibration",
+                       "Calibration time out",
+                       NULL,
+                       3,
+                       false);
+        return;
+    }
+
+    if (!getting_data) {  //heading refresh when not calibrating
         zsw_sensor_fusion_get_heading(&heading);
         compass_ui_set_heading(heading);
     }

--- a/app/src/applications/compass/compass_app.c
+++ b/app/src/applications/compass/compass_app.c
@@ -26,14 +26,11 @@
 #include "sensor_fusion/zsw_sensor_fusion.h"
 #include "ui/utils/zsw_ui_utils.h"
 
-
 LOG_MODULE_REGISTER(compass_app, LOG_LEVEL_DBG);
 
-// Functions needed for all applications
 static void compass_app_start(lv_obj_t *root, lv_group_t *group);
 static void compass_app_stop(void);
 
-// Functions related to app functionality
 static void timer_callback(lv_timer_t *timer);
 static void on_start_calibration(void);
 
@@ -51,21 +48,23 @@ static lv_timer_t *refresh_timer;
 static bool getting_data;
 static uint32_t cal_start_ms;
 
-#define CONFIG_BOARD_NATIVE_SIM
-
-
-#ifdef CONFIG_BOARD_NATIVE_SIM
-static int p; //track dummy progress
-#endif
-
 static void compass_app_start(lv_obj_t *root, lv_group_t *group)
 {
     compass_ui_show(root, on_start_calibration);
+
+    if (zsw_magnetometer_recalibration_required()) {
+    zsw_popup_show("Calibration",
+                 "Compass calibration format changed. Please recalibrate.",
+                 NULL,
+                 5,
+                 false);
+    }
+
     refresh_timer = lv_timer_create(timer_callback, CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_REFRESH_INTERVAL_MS,  NULL);
     zsw_sensor_fusion_init();
 }
 
-static void compass_app_stop(void) //app lifecycle callback that runs when the Compass app is closed or switched away from
+static void compass_app_stop(void)
 {
     if (refresh_timer) {
         lv_timer_del(refresh_timer);
@@ -75,10 +74,10 @@ static void compass_app_stop(void) //app lifecycle callback that runs when the C
     zsw_sensor_fusion_deinit();
 
     if (getting_data) {
-        getting_data = false;
-        zsw_popup_remove();
-
-    }
+      getting_data = false;
+      zsw_magnetometer_cancel_calibration();
+      zsw_popup_remove();
+}
 }
 
 
@@ -90,11 +89,15 @@ static void on_start_calibration(void)
 
     zsw_popup_remove();
 
-    zsw_magnetometer_gather_data();
-
-    #ifdef CONFIG_BOARD_NATIVE_SIM
-    p = 0;
-    #endif
+    int ret = zsw_magnetometer_gather_data();
+    if (ret != 0) {
+        zsw_popup_show("Calibration",
+                       "Failed to start calibration",
+                       NULL,
+                       3,
+                       false);
+        return;
+    }
 
     getting_data = true;
     cal_start_ms = lv_tick_get();
@@ -103,70 +106,64 @@ static void on_start_calibration(void)
 }
 
 
-// Now used for:
-//1. Calibration data gathering timeout failure - progress bars decide success; timer only catches timeout.
-//2. heading refresh when not calibrating (as before)
-
-static void timer_callback(lv_timer_t *timer) //runs every however many milliseconds
+static void timer_callback(lv_timer_t *timer)
 {
     float heading;
+    bool app_visible = app.current_state == ZSW_APP_STATE_UI_VISIBLE;
 
-    #ifdef CONFIG_BOARD_NATIVE_SIM
-    if (getting_data) {
+    if (getting_data && app_visible) {
 
-        p += 5;
-        //if //(p > 100) {
-            //p = 100;
-        //}
+        int px;
+        int py;
+        int pz;
 
+        if (zsw_magnetometer_get_calibration_progress(&px, &py, &pz) == 0) {
+            compass_ui_set_calibration_progress(px, py, pz);
+        }
 
-        compass_ui_set_calibration_progress(p, p, p);
     }
-    #endif
 
-
-    //when we have enough data and we can try the calc the compensation
     if (getting_data &&
-        zsw_magnetometer_calibration_ready()) { //ie we have enough data
+        zsw_magnetometer_calibration_ready()) {
 
-        int ret = zsw_magnetometer_compute_compensation();  //try to compute offsets
+        int ret = zsw_magnetometer_compute_compensation();
 
         getting_data = false;
-        compass_ui_hide_calibration();
 
-        if (ret == 0) {
-            zsw_popup_show("Calibration",
-                           "Calibration successful",
-                           NULL,
-                           3,
-                           false);
-        } else {
-            zsw_popup_show("Calibration",
-                           "Calibration failed",
-                           NULL,
-                           3,
-                           false);
+        if (app_visible) {
+            compass_ui_hide_calibration();
+
+            if (ret == 0) {
+                zsw_popup_show("Calibration", "Calibration successful", NULL, 3, false);
+            } else {
+                zsw_popup_show("Calibration", "Calibration failed", NULL, 3, false);
+            }
         }
 
         return;
-    }
 
 
-    if (getting_data && //time is up
+
+        }
+
+
+    if (getting_data &&
         lv_tick_elaps(cal_start_ms) >=
         (CONFIG_APPLICATIONS_CONFIGURATION_COMPASS_CALIBRATION_TIME_S * 1000UL)) {
         getting_data = false;
-        compass_ui_hide_calibration();
+        zsw_magnetometer_cancel_calibration();
 
-        zsw_popup_show("Calibration",
-                       "Calibration time out",
-                       NULL,
-                       3,
-                       false);
-        return;
-    }
+        if (app_visible) {
+          compass_ui_hide_calibration();
+          zsw_popup_show("Calibration", "Calibration time out", NULL, 3, false);
+          }
 
-    if (!getting_data) {  //heading refresh when not calibrating
+          return;
+
+          }
+
+
+    if (!getting_data && app_visible) {  //heading refresh when not calibrating
         zsw_sensor_fusion_get_heading(&heading);
         compass_ui_set_heading(heading);
     }

--- a/app/src/applications/compass/compass_app.c
+++ b/app/src/applications/compass/compass_app.c
@@ -76,9 +76,9 @@ static void compass_app_stop(void)
     if (getting_data) {
         getting_data = false;
         zsw_magnetometer_cancel_calibration();
-        zsw_popup_remove();
-    }
 
+    }
+    zsw_popup_remove();
     compass_ui_remove();
     zsw_sensor_fusion_deinit();
 }

--- a/app/src/applications/compass/compass_ui.c
+++ b/app/src/applications/compass/compass_ui.c
@@ -24,7 +24,13 @@ static lv_obj_t *root_page = NULL;
 static lv_obj_t *compass_img;
 static lv_obj_t *compass_label;
 
-static on_start_calibraion_cb_t start_cal;
+static on_start_calibration_cb_t start_cal;
+
+static lv_obj_t *calibration_panel;
+static lv_obj_t *bar_x;
+static lv_obj_t *bar_y;
+static lv_obj_t *bar_z;
+
 
 static void calibrate_button_event_cb(lv_event_t *e)
 {
@@ -67,7 +73,7 @@ static void create_ui(lv_obj_t *compass_panel)
     lv_obj_set_style_text_opa(compass_label, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 }
 
-void compass_ui_show(lv_obj_t *root, on_start_calibraion_cb_t start_cal_cb)
+void compass_ui_show(lv_obj_t *root, on_start_calibration_cb_t start_cal_cb)
 {
     assert(root_page == NULL);
 
@@ -95,4 +101,82 @@ void compass_ui_set_heading(double heading)
 {
     lv_label_set_text_fmt(compass_label, "%.0f°", heading);
     lv_img_set_angle(compass_img, heading * 10);
+}
+
+
+void compass_ui_show_calibration(void)
+{
+    if (!root_page) {
+        return;
+    }
+
+    if (calibration_panel) {
+        return;
+    }
+
+    calibration_panel = lv_obj_create(root_page);
+    lv_obj_set_size(calibration_panel, LV_PCT(100), 80);
+    lv_obj_align(calibration_panel, LV_ALIGN_TOP_MID, 0, 35);
+    lv_obj_set_style_border_width(calibration_panel, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(calibration_panel, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_clear_flag(calibration_panel, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t *label;
+
+    label = lv_label_create(calibration_panel);
+    lv_label_set_text(label, "X");
+    lv_obj_align(label, LV_ALIGN_TOP_LEFT, 10, 5);
+
+    bar_x = lv_bar_create(calibration_panel);
+    lv_obj_set_size(bar_x, 150, 12);
+    lv_obj_align(bar_x, LV_ALIGN_TOP_LEFT, 35, 5);
+    lv_bar_set_range(bar_x, 0, 100);
+    lv_bar_set_value(bar_x, 0, LV_ANIM_OFF);
+
+    label = lv_label_create(calibration_panel);
+    lv_label_set_text(label, "Y");
+    lv_obj_align(label, LV_ALIGN_TOP_LEFT, 10, 30);
+
+    bar_y = lv_bar_create(calibration_panel);
+    lv_obj_set_size(bar_y, 150, 12);
+    lv_obj_align(bar_y, LV_ALIGN_TOP_LEFT, 35, 30);
+    lv_bar_set_range(bar_y, 0, 100);
+    lv_bar_set_value(bar_y, 0, LV_ANIM_OFF);
+
+    label = lv_label_create(calibration_panel);
+    lv_label_set_text(label, "Z");
+    lv_obj_align(label, LV_ALIGN_TOP_LEFT, 10, 55);
+
+    bar_z = lv_bar_create(calibration_panel);
+    lv_obj_set_size(bar_z, 150, 12);
+    lv_obj_align(bar_z, LV_ALIGN_TOP_LEFT, 35, 55);
+    lv_bar_set_range(bar_z, 0, 100);
+    lv_bar_set_value(bar_z, 0, LV_ANIM_OFF);
+}
+
+void compass_ui_hide_calibration(void)
+{
+    if (calibration_panel) {
+        lv_obj_del(calibration_panel);
+        calibration_panel = NULL;
+    }
+
+    bar_x = NULL;
+    bar_y = NULL;
+    bar_z = NULL;
+}
+
+void compass_ui_set_calibration_progress(int px, int py, int pz)
+{
+    if (!bar_x || !bar_y || !bar_z) {
+        return;
+    }
+
+    px = LV_CLAMP(0, px, 100);
+    py = LV_CLAMP(0, py, 100);
+    pz = LV_CLAMP(0, pz, 100);
+
+    lv_bar_set_value(bar_x, px, LV_ANIM_OFF);
+    lv_bar_set_value(bar_y, py, LV_ANIM_OFF);
+    lv_bar_set_value(bar_z, pz, LV_ANIM_OFF);
 }

--- a/app/src/applications/compass/compass_ui.c
+++ b/app/src/applications/compass/compass_ui.c
@@ -93,8 +93,14 @@ void compass_ui_show(lv_obj_t *root, on_start_calibration_cb_t start_cal_cb)
 
 void compass_ui_remove(void)
 {
-    lv_obj_del(root_page);
-    root_page = NULL;
+    compass_ui_hide_calibration();
+
+    if (root_page) {
+        lv_obj_del(root_page);
+        root_page = NULL;
+    }
+
+    start_cal = NULL;
 }
 
 void compass_ui_set_heading(double heading)

--- a/app/src/applications/compass/compass_ui.h
+++ b/app/src/applications/compass/compass_ui.h
@@ -20,10 +20,16 @@
 #include <inttypes.h>
 #include <lvgl.h>
 
-typedef void(*on_start_calibraion_cb_t)(void);
+typedef void(*on_start_calibration_cb_t)(void);
 
-void compass_ui_show(lv_obj_t *root, on_start_calibraion_cb_t start_cal_cb);
+void compass_ui_show(lv_obj_t *root, on_start_calibration_cb_t start_cal_cb);
 
 void compass_ui_remove(void);
 
 void compass_ui_set_heading(double heading);
+
+void compass_ui_show_calibration(void);
+
+void compass_ui_hide_calibration(void);
+
+void compass_ui_set_calibration_progress(int px, int py, int pz);

--- a/app/src/ext/magnetometer_calibration/eigen.c
+++ b/app/src/ext/magnetometer_calibration/eigen.c
@@ -1,0 +1,113 @@
+#include "eigen.h"
+
+#include "stdlib.h"
+#include "assert.h"
+#include "qr.h"
+
+#define EIGEN_TOLERANCE 1.0E-6
+#define EIGEN_SINGULARITY_TOLERANCE 1.0E-10
+#define EIGEN_MAX_ITER 100
+
+Vector eig_solve_eigenvalues(Matrix M) {
+    Matrix X = mat_copy(M);
+    int i = 0;
+    do {
+        QR_t qr = qr_decomposition(X);
+        Matrix RQ = mat_multiply(qr.R, qr.Q);
+        mat_replace(X, RQ);
+        qr_free(qr);
+        i++;
+    } while (!mat_is_upper_triang(X, EIGEN_TOLERANCE) && (i < EIGEN_MAX_ITER));
+    Vector res = mat_get_diag(X);
+    mat_free(X);
+    return res;
+}
+
+Vector linsolve_from_qr(QR_t qr, Vector b) {
+    Vector rhs = mat_multiply_vec(qr.Q, b);
+    Vector solution = mat_linsolve_upperr_triang(qr.R, rhs);
+    vec_free(rhs);
+    return solution;
+}
+
+Vector linsolve_qr(Matrix matA, Vector b) {
+    assert(matA->rows == b->size);
+    QR_t qr = qr_decomposition(matA);
+    Vector solution = linsolve_from_qr(qr, b);
+    qr_free(qr);
+    return solution;
+}
+
+Vector eigen_backsolve(Matrix matA, double eigVal) {
+    Vector current = vec_new(matA->rows);
+    vec_fill(current, 1);
+    Vector previous = NULL;
+    double lambda = eigVal + ((double) rand() / (double) RAND_MAX) * 0.000001;
+    Matrix matLambda = mat_new(matA->rows, matA->columns);
+    mat_fill_diag(matLambda, lambda);
+    Matrix matMinusLambda = mat_copy(matA);
+    mat_sub(matMinusLambda, matLambda);
+    mat_free(matLambda);
+
+    int i = 0;
+    do {
+        if (i > 0) {
+            vec_free(previous);
+        }
+        previous = current;
+        current = linsolve_qr(matMinusLambda, previous);
+
+        if (VEC_ELEM(current, 0) < 0) {
+            vec_negate(current);
+        }
+        vec_normalize(current);
+        i++;
+    } while (!vec_equal(current, previous, EIGEN_TOLERANCE) && (i < EIGEN_MAX_ITER));
+    mat_free(matMinusLambda);
+    vec_free(previous);
+    return current;
+}
+Matrix eigen_solve_eigenvectors(Matrix matA, Vector eigenvalues) {
+    assert(eigenvalues->size = matA->rows);
+    assert(eigenvalues->size = matA->columns);
+
+    double eigVal;
+    int eigCount = matA->columns;
+    Matrix eigenvectors = mat_new(eigCount, eigCount);
+
+    for (int i = 0; i < eigCount; i++) {
+        eigVal = VEC_ELEM(eigenvalues, i);
+        Vector eigenvector = eigen_backsolve(matA, eigVal);
+        mat_paste_column(eigenvectors, eigenvector, i);
+        vec_free(eigenvector);
+    }
+
+    return eigenvectors;
+}
+Eigen_t eig_solve(Matrix matA) {
+    assert(matA->columns == matA->rows);
+
+    Eigen_t res;
+    res.eigenvalues = eig_solve_eigenvalues(matA);
+    res.eigenvectors = eigen_solve_eigenvectors(matA, res.eigenvalues);
+    return res;
+}
+
+Vector eig_eigvec_of_largest_eigval(Eigen_t eigA) {
+    assert(eigA.eigenvalues->size > 0);
+
+    double largestEigval = VEC_ELEM(eigA.eigenvalues, 0);
+    unsigned int largestEigvalId = 0;
+    for (int i = 1; i < eigA.eigenvalues->size; i++) {
+        if (VEC_ELEM(eigA.eigenvalues, i) > largestEigval) {
+            largestEigval = VEC_ELEM(eigA.eigenvalues, i);
+            largestEigvalId = i;
+        }
+    }
+    return mat_copy_column(eigA.eigenvectors, largestEigvalId);
+}
+
+void eig_free(Eigen_t eigA) {
+    vec_free(eigA.eigenvalues);
+    mat_free(eigA.eigenvectors);
+}

--- a/app/src/ext/magnetometer_calibration/eigen.c
+++ b/app/src/ext/magnetometer_calibration/eigen.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "eigen.h"
 
 #include "stdlib.h"
@@ -68,8 +85,8 @@ Vector eigen_backsolve(Matrix matA, double eigVal) {
     return current;
 }
 Matrix eigen_solve_eigenvectors(Matrix matA, Vector eigenvalues) {
-    assert(eigenvalues->size = matA->rows);
-    assert(eigenvalues->size = matA->columns);
+    assert(eigenvalues->size == matA->rows);
+    assert(eigenvalues->size == matA->columns);
 
     double eigVal;
     int eigCount = matA->columns;

--- a/app/src/ext/magnetometer_calibration/eigen.c
+++ b/app/src/ext/magnetometer_calibration/eigen.c
@@ -40,10 +40,15 @@ Vector eig_solve_eigenvalues(Matrix M) {
     return res;
 }
 
-Vector linsolve_from_qr(QR_t qr, Vector b) {
-    Vector rhs = mat_multiply_vec(qr.Q, b);
+Vector linsolve_from_qr(QR_t qr, Vector b)
+{
+    Matrix Qt = mat_transpose(qr.Q);
+    Vector rhs = mat_multiply_vec(Qt, b);
+    mat_free(Qt);
+
     Vector solution = mat_linsolve_upperr_triang(qr.R, rhs);
     vec_free(rhs);
+
     return solution;
 }
 

--- a/app/src/ext/magnetometer_calibration/eigen.h
+++ b/app/src/ext/magnetometer_calibration/eigen.h
@@ -1,0 +1,16 @@
+#ifndef COMPONENTS_GEOMETRY_EIGEN_H_
+#define COMPONENTS_GEOMETRY_EIGEN_H_
+
+#include "matrix.h"
+#include "vector.h"
+
+typedef struct {
+    Vector eigenvalues;
+    Matrix eigenvectors;
+} Eigen_t;
+
+Eigen_t eig_solve(Matrix matA);
+Vector eig_eigvec_of_largest_eigval(Eigen_t eigA);
+void eig_free(Eigen_t eigA);
+
+#endif  // COMPONENTS_GEOMETRY_EIGEN_H_

--- a/app/src/ext/magnetometer_calibration/eigen.h
+++ b/app/src/ext/magnetometer_calibration/eigen.h
@@ -1,5 +1,21 @@
-#ifndef COMPONENTS_GEOMETRY_EIGEN_H_
-#define COMPONENTS_GEOMETRY_EIGEN_H_
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include "matrix.h"
 #include "vector.h"
@@ -13,4 +29,4 @@ Eigen_t eig_solve(Matrix matA);
 Vector eig_eigvec_of_largest_eigval(Eigen_t eigA);
 void eig_free(Eigen_t eigA);
 
-#endif  // COMPONENTS_GEOMETRY_EIGEN_H_
+

--- a/app/src/ext/magnetometer_calibration/ellipsoid_fit.c
+++ b/app/src/ext/magnetometer_calibration/ellipsoid_fit.c
@@ -1,0 +1,79 @@
+#include "ellipsoid_fit.h"
+
+#include "assert.h"
+#include "matrix.h"
+#include "eigen.h"
+
+#define ALPHA 16
+
+Matrix ellipsoid_generate_data_mat(Vector x, Vector y, Vector z) {
+    assert(x->size == y->size);
+    assert(x->size == z->size);
+    Matrix res = mat_new(10, x->size);
+    for (int i = 0; i < res->columns; i++) {
+        MAT_ELEM(res, 0, i) = VEC_ELEM(x, i) * VEC_ELEM(x, i);
+        MAT_ELEM(res, 1, i) = VEC_ELEM(y, i) * VEC_ELEM(y, i);
+        MAT_ELEM(res, 2, i) = VEC_ELEM(z, i) * VEC_ELEM(z, i);
+
+        MAT_ELEM(res, 3, i) = 2 * VEC_ELEM(y, i) * VEC_ELEM(z, i);
+        MAT_ELEM(res, 4, i) = 2 * VEC_ELEM(x, i) * VEC_ELEM(z, i);
+        MAT_ELEM(res, 5, i) = 2 * VEC_ELEM(x, i) * VEC_ELEM(y, i);
+
+        MAT_ELEM(res, 6, i) = 2 * VEC_ELEM(x, i);
+        MAT_ELEM(res, 7, i) = 2 * VEC_ELEM(y, i);
+        MAT_ELEM(res, 8, i) = 2 * VEC_ELEM(z, i);
+
+        MAT_ELEM(res, 9, i) = 1;
+    }
+    return res;
+}
+double C_inv[] = {(double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA), -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA),
+                        -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), 0, 0, 0,
+                        -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), (double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA),
+                        -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), 0, 0, 0,
+                        -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA),
+                        (double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA), 0, 0, 0,
+                        0, 0, 0, -1.f/ALPHA, 0, 0,
+                        0, 0, 0, 0, -1.f/ALPHA, 0,
+                        0, 0, 0, 0, 0, -1.f/ALPHA};
+Matrix ellipsoid_generate_inverse_restrain_mat() {
+    return mat_from_array(C_inv, 6, 6);
+}
+
+Ellipsoid_t ellipsoid_fit(Vector x, Vector y, Vector z) {
+    Matrix dataM = ellipsoid_generate_data_mat(x, y, z);
+    Matrix invC = ellipsoid_generate_inverse_restrain_mat();
+    Matrix S = mat_multiply_MMT(dataM);
+    mat_free(dataM);
+    Matrix S11 = mat_copy_submat(S, 0, 0, 6, 6);
+    Matrix S12 = mat_copy_submat(S, 0, 6, 6, 4);
+    Matrix S21 = mat_copy_submat(S, 6, 0, 4, 6);
+    Matrix invS22 = mat_copy_submat(S, 6, 6, 4, 4);
+    mat_inv_4x4(invS22);
+    mat_free(S);
+    // M = C1^-1*(S11-S12*(S22^-1*S21));
+    Matrix invS22_S21 = mat_multiply(invS22, S21);
+    mat_free(S21);
+    mat_free(invS22);
+    Matrix S12_invS22_S21 = mat_multiply(S12, invS22_S21);
+    mat_free(S12);
+    mat_sub(S11, S12_invS22_S21);
+    mat_free(S12_invS22_S21);
+    Matrix M = mat_multiply(invC, S11);
+    mat_free(S11);
+    mat_from_array_free(invC);
+    Eigen_t eig = eig_solve(M);
+    mat_free(M);
+    Ellipsoid_t res;
+    res.coefA = eig_eigvec_of_largest_eigval(eig);
+    eig_free(eig);
+    res.coefB = mat_multiply_vec(invS22_S21, res.coefA);
+    vec_negate(res.coefB);
+    mat_free(invS22_S21);
+    return res;
+}
+
+void ellipsoid_free(Ellipsoid_t elip) {
+    vec_free(elip.coefA);
+    vec_free(elip.coefB);
+}

--- a/app/src/ext/magnetometer_calibration/ellipsoid_fit.c
+++ b/app/src/ext/magnetometer_calibration/ellipsoid_fit.c
@@ -1,3 +1,21 @@
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
 #include "ellipsoid_fit.h"
 
 #include "assert.h"
@@ -6,7 +24,7 @@
 
 #define ALPHA 16
 
-Matrix ellipsoid_generate_data_mat(Vector x, Vector y, Vector z) {
+static Matrix ellipsoid_generate_data_mat(Vector x, Vector y, Vector z) {
     assert(x->size == y->size);
     assert(x->size == z->size);
     Matrix res = mat_new(10, x->size);
@@ -27,7 +45,8 @@ Matrix ellipsoid_generate_data_mat(Vector x, Vector y, Vector z) {
     }
     return res;
 }
-double C_inv[] = {(double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA), -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA),
+
+static const double C_inv[] = {(double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA), -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA),
                         -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), 0, 0, 0,
                         -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), (double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA),
                         -(double)(ALPHA - 2)/(- ALPHA*ALPHA + 3*ALPHA), 0, 0, 0,
@@ -36,7 +55,7 @@ double C_inv[] = {(double)(ALPHA - 4)/(- ALPHA*ALPHA + 3*ALPHA), -(double)(ALPHA
                         0, 0, 0, -1.f/ALPHA, 0, 0,
                         0, 0, 0, 0, -1.f/ALPHA, 0,
                         0, 0, 0, 0, 0, -1.f/ALPHA};
-Matrix ellipsoid_generate_inverse_restrain_mat() {
+static Matrix ellipsoid_generate_inverse_restrain_mat(void) {
     return mat_from_array(C_inv, 6, 6);
 }
 

--- a/app/src/ext/magnetometer_calibration/ellipsoid_fit.c
+++ b/app/src/ext/magnetometer_calibration/ellipsoid_fit.c
@@ -21,6 +21,7 @@
 #include "assert.h"
 #include "matrix.h"
 #include "eigen.h"
+#include <stddef.h>
 
 #define ALPHA 16
 
@@ -68,8 +69,25 @@ Ellipsoid_t ellipsoid_fit(Vector x, Vector y, Vector z) {
     Matrix S12 = mat_copy_submat(S, 0, 6, 6, 4);
     Matrix S21 = mat_copy_submat(S, 6, 0, 4, 6);
     Matrix invS22 = mat_copy_submat(S, 6, 6, 4, 4);
-    mat_inv_4x4(invS22);
-    mat_free(S);
+
+    if (!mat_inv_4x4(invS22)) {
+         mat_free(S);
+         mat_free(S11);
+         mat_free(S12);
+         mat_free(S21);
+         mat_free(invS22);
+         mat_from_array_free(invC);
+
+         Ellipsoid_t fail = {
+             .coefA = NULL,
+             .coefB = NULL,
+         };
+
+         return fail;
+     }
+
+     mat_free(S);
+
     // M = C1^-1*(S11-S12*(S22^-1*S21));
     Matrix invS22_S21 = mat_multiply(invS22, S21);
     mat_free(S21);

--- a/app/src/ext/magnetometer_calibration/ellipsoid_fit.h
+++ b/app/src/ext/magnetometer_calibration/ellipsoid_fit.h
@@ -1,0 +1,14 @@
+#ifndef COMPONENTS_GEOMETRY_ELLIPSOID_FIT_H_
+#define COMPONENTS_GEOMETRY_ELLIPSOID_FIT_H_
+
+#include "vector.h"
+
+typedef struct {
+    Vector coefA;
+    Vector coefB;
+} Ellipsoid_t;
+
+Ellipsoid_t ellipsoid_fit(Vector x, Vector y, Vector z);
+void ellipsoid_free(Ellipsoid_t elip);
+
+#endif  // COMPONENTS_GEOMETRY_ELLIPSOID_FIT_H_

--- a/app/src/ext/magnetometer_calibration/ellipsoid_fit.h
+++ b/app/src/ext/magnetometer_calibration/ellipsoid_fit.h
@@ -1,5 +1,21 @@
-#ifndef COMPONENTS_GEOMETRY_ELLIPSOID_FIT_H_
-#define COMPONENTS_GEOMETRY_ELLIPSOID_FIT_H_
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include "vector.h"
 
@@ -10,5 +26,3 @@ typedef struct {
 
 Ellipsoid_t ellipsoid_fit(Vector x, Vector y, Vector z);
 void ellipsoid_free(Ellipsoid_t elip);
-
-#endif  // COMPONENTS_GEOMETRY_ELLIPSOID_FIT_H_

--- a/app/src/ext/magnetometer_calibration/matrix.c
+++ b/app/src/ext/magnetometer_calibration/matrix.c
@@ -1,0 +1,461 @@
+#include "matrix.h"
+
+#include "stdlib.h"
+#include "stdio.h"
+#include "assert.h"
+#include "math.h"
+
+Matrix mat_new(const unsigned int rows, const unsigned int columns) {
+    Matrix res = malloc(sizeof(Matrix_t));
+    res->rows = rows;
+    res->columns = columns;
+    res->data = calloc(rows*columns, sizeof(double));
+    return res;
+}
+Matrix mat_new_I(const unsigned int rowsColumns) {
+    Matrix res = mat_new(rowsColumns, rowsColumns);
+    mat_fill_diag(res, 1);
+    return res;
+}
+Matrix mat_copy(Matrix matA) {
+    Matrix res = mat_new(matA->rows, matA->columns);
+    mat_rewrite(res, matA);
+    return res;
+}
+Matrix mat_copy_submat(Matrix matA, const unsigned int frow, const unsigned int fcolumn,
+                                    const unsigned int rows, const unsigned int columns) {
+    assert(matA->rows >= frow + rows);
+    assert(matA->columns >= fcolumn + columns);
+
+    Matrix res = mat_new(rows, columns);
+    for (int i = 0; i < res->rows; i++) {
+        for (int j = 0; j < res->columns; j++) {
+            MAT_ELEM(res, i, j) = MAT_ELEM(matA, i + frow, j + fcolumn);
+        }
+    }
+    return res;
+}
+Matrix mat_from_array(const double *array, const unsigned int rows, const unsigned int columns) {
+    Matrix res = malloc(sizeof(Matrix_t));
+    res->rows = columns;
+    res->columns = columns;
+    res->data = array;
+    return res;
+}
+void mat_replace(Matrix matA, Matrix matB) {
+    free(matA->data);
+    matA->rows = matB->rows;
+    matA->columns = matB->columns;
+    matA->data = matB->data;
+    free(matB);
+}
+Vector mat_copy_column(Matrix matA, const unsigned int column) {
+    assert(matA->columns > column);
+
+    Vector res = vec_new(matA->rows);
+    for (int i = 0; i < matA->rows; i++) {
+        VEC_ELEM(res, i) = MAT_ELEM(matA, i, column);
+    }
+    return res;
+}
+void mat_paste_column(Matrix matA, Vector vecB, const unsigned int column) {
+    assert(matA->columns > column);
+
+    for (int i = 0; i < matA->rows; i++) {
+        MAT_ELEM(matA, i, column) = VEC_ELEM(vecB, i);
+    }
+}
+Vector mat_get_diag(Matrix matA) {
+    assert(matA->rows == matA->columns);
+
+    Vector res = vec_new(matA->rows);
+    for (int i = 0; i < matA->rows; i++) {
+        VEC_ELEM(res, i) = MAT_ELEM(matA, i, i);
+    }
+    return res;
+}
+void mat_fill(Matrix matA, double val) {
+    for (int i = 0; i < matA->rows * matA->columns; i++)  {
+        MAT_ELEM_FLAT(matA, i) = val;
+    }
+}
+void mat_fill_diag(Matrix matA, double val) {
+    assert(matA->rows == matA->rows);
+    for (int i = 0; i < matA->rows; i++)  {
+        MAT_ELEM(matA, i, i) = val;
+    }
+}
+void mat_rewrite(Matrix matA, Matrix matB) {
+    assert(matA->rows == matB->rows);
+    assert(matA->columns == matB->columns);
+    for (int i = 0; i < matA->rows * matA->columns; i++)  {
+        MAT_ELEM_FLAT(matA, i) = MAT_ELEM_FLAT(matB, i);
+    }
+}
+Matrix mat_multiply(Matrix matA, Matrix matB) {
+    assert(matA->columns == matB->rows);
+    Matrix res = mat_new(matA->rows, matB->columns);
+    for (int i = 0; i < res->rows; i++) {
+        for (int j = 0; j < res->columns; j++) {
+            for (int k = 0; k < matA->columns; k++) {
+                MAT_ELEM(res, i, j) += MAT_ELEM(matA, i, k) * MAT_ELEM(matB, k, j);
+            }
+        }
+    }
+    return res;
+}
+void mat_multiply_vec3_into(Matrix matA, Vector vecB) {
+    assert(vecB->size == matA->columns);
+    assert(matA->rows == matA->columns);
+
+    double tempX = VEC_X(vecB);
+    double tempY = VEC_Y(vecB);
+    VEC_X(vecB) = MAT_ELEM(matA, 0, 0) * tempX + MAT_ELEM(matA, 0, 1) * tempY + MAT_ELEM(matA, 0, 2) * VEC_Z(vecB);
+    VEC_Y(vecB) = MAT_ELEM(matA, 1, 0) * tempX + MAT_ELEM(matA, 1, 1) * tempY + MAT_ELEM(matA, 1, 2) * VEC_Z(vecB);
+    VEC_Z(vecB) = MAT_ELEM(matA, 2, 0) * tempX + MAT_ELEM(matA, 2, 1) * tempY + MAT_ELEM(matA, 2, 2) * VEC_Z(vecB);
+}
+Matrix mat_multiply_MMT(Matrix matA) {
+    Matrix res = mat_new(matA->rows, matA->rows);
+    for (int i = 0; i < res->rows; i++) {
+        for (int j = 0; j < res->columns; j++) {
+            for (int k = 0; k < matA->columns; k++) {
+                MAT_ELEM(res, i, j) += MAT_ELEM(matA, i, k) * MAT_ELEM(matA, j, k);
+            }
+        }
+    }
+    return res;
+}
+Vector mat_multiply_vec(Matrix matA, Vector vecB) {
+    assert(matA->columns == vecB->size);
+    Vector res = vec_new(matA->rows);
+    for (int i = 0; i < res->size; i++) {
+        for (int k = 0; k < matA->columns; k++) {
+            VEC_ELEM(res, i) += MAT_ELEM(matA, i, k) * VEC_ELEM(vecB, k);
+        }
+    }
+    return res;
+}
+Vector vec_multiply_mat(Vector vecA, Matrix matB) {
+    assert(vecA->size == matB->rows);
+    Vector res = vec_new(matB->columns);
+    for (int i = 0; i < res->size; i++) {
+        for (int k = 0; k < matB->rows; k++) {
+            VEC_ELEM(res, i) += VEC_ELEM(vecA, k) * MAT_ELEM(matB, k, i);
+        }
+    }
+    return res;
+}
+void mat_add(Matrix matA, Matrix matB) {
+    assert(matA->rows == matB->rows);
+    assert(matA->columns == matB->columns);
+
+    for (int i = 0; i < matA->rows * matA->columns; i++)  {
+        MAT_ELEM_FLAT(matA, i) += MAT_ELEM_FLAT(matB, i);
+    }
+}
+
+void mat_sub(Matrix matA, Matrix matB) {
+    assert(matA->rows == matB->rows);
+    assert(matA->columns == matB->columns);
+
+    for (int i = 0; i < matA->rows * matA->columns; i++)  {
+        MAT_ELEM_FLAT(matA, i) -= MAT_ELEM_FLAT(matB, i);
+    }
+}
+Matrix mat_transpose(Matrix matA) {
+    Matrix res = mat_new(matA->columns, matA->rows);
+    for (int i = 0; i < res->rows; i++) {
+        for (int j = 0; j < res->columns; j++) {
+            MAT_ELEM(res, i, j) = MAT_ELEM(matA, j, i);
+        }
+    }
+    return res;
+}
+void mat_orthogonalize(Matrix matA) {
+    assert(matA->rows == matA->columns);
+    for (int i = 1; i < matA->columns; i++) {
+        Vector column = mat_copy_column(matA, i);
+        for (int j = 1; j < i; j++) {
+            Vector prevColumn =  mat_copy_column(matA, j);
+            vec_multiply_scalar(prevColumn, vec_dot_product(prevColumn, column));
+            vec_sub(column, prevColumn);
+            vec_free(prevColumn);
+        }
+        vec_normalize(column);
+        mat_paste_column(matA, column, i);
+        vec_free(column);
+    }
+}
+bool mat_is_upper_triang(Matrix matA, double tol) {
+    assert(matA->rows == matA->columns);
+
+    for (int i = 0; i < matA->rows; i++) {
+        for (int j = 0; j < i; j++) {
+            if (fabs(MAT_ELEM(matA, i, j)) > tol) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool mat_check_nan(Matrix matA) {
+    for (int i = 0; i < matA->rows*matA->columns; i++) {
+        if (MAT_ELEM_FLAT(matA, i) != MAT_ELEM_FLAT(matA, i))
+            return true;
+    }
+    return false;
+}
+
+Vector mat_linsolve_upperr_triang(Matrix R, Vector b) {
+    assert(R->columns == b->size);
+    assert(R->rows == R->columns);
+
+    Vector solution = vec_new(b->size);
+    float back_substitute;
+    for (int i = b->size - 1; i >= 0; i--) {
+        back_substitute = 0;
+        for (int j = i+1; j <= b->size - 1; j++) {
+            back_substitute += VEC_ELEM(solution, j) * MAT_ELEM(R, i, j);
+        }
+        VEC_ELEM(solution, i) =
+            (VEC_ELEM(b, i) - back_substitute) / MAT_ELEM(R, i, i);
+    }
+    return solution;
+}
+
+bool mat_inv_4x4(Matrix matA) {
+    double inv[16], det;
+
+    double *m = matA->data;
+    inv[0] = m[5]  * m[10] * m[15] -
+             m[5]  * m[11] * m[14] -
+             m[9]  * m[6]  * m[15] +
+             m[9]  * m[7]  * m[14] +
+             m[13] * m[6]  * m[11] -
+             m[13] * m[7]  * m[10];
+
+    inv[4] = -m[4]  * m[10] * m[15] +
+              m[4]  * m[11] * m[14] +
+              m[8]  * m[6]  * m[15] -
+              m[8]  * m[7]  * m[14] -
+              m[12] * m[6]  * m[11] +
+              m[12] * m[7]  * m[10];
+
+    inv[8] = m[4]  * m[9] * m[15] -
+             m[4]  * m[11] * m[13] -
+             m[8]  * m[5] * m[15] +
+             m[8]  * m[7] * m[13] +
+             m[12] * m[5] * m[11] -
+             m[12] * m[7] * m[9];
+
+    inv[12] = -m[4]  * m[9] * m[14] +
+               m[4]  * m[10] * m[13] +
+               m[8]  * m[5] * m[14] -
+               m[8]  * m[6] * m[13] -
+               m[12] * m[5] * m[10] +
+               m[12] * m[6] * m[9];
+
+    inv[1] = -m[1]  * m[10] * m[15] +
+              m[1]  * m[11] * m[14] +
+              m[9]  * m[2] * m[15] -
+              m[9]  * m[3] * m[14] -
+              m[13] * m[2] * m[11] +
+              m[13] * m[3] * m[10];
+
+    inv[5] = m[0]  * m[10] * m[15] -
+             m[0]  * m[11] * m[14] -
+             m[8]  * m[2] * m[15] +
+             m[8]  * m[3] * m[14] +
+             m[12] * m[2] * m[11] -
+             m[12] * m[3] * m[10];
+
+    inv[9] = -m[0]  * m[9] * m[15] +
+              m[0]  * m[11] * m[13] +
+              m[8]  * m[1] * m[15] -
+              m[8]  * m[3] * m[13] -
+              m[12] * m[1] * m[11] +
+              m[12] * m[3] * m[9];
+
+    inv[13] = m[0]  * m[9] * m[14] -
+              m[0]  * m[10] * m[13] -
+              m[8]  * m[1] * m[14] +
+              m[8]  * m[2] * m[13] +
+              m[12] * m[1] * m[10] -
+              m[12] * m[2] * m[9];
+
+    inv[2] = m[1]  * m[6] * m[15] -
+             m[1]  * m[7] * m[14] -
+             m[5]  * m[2] * m[15] +
+             m[5]  * m[3] * m[14] +
+             m[13] * m[2] * m[7] -
+             m[13] * m[3] * m[6];
+
+    inv[6] = -m[0]  * m[6] * m[15] +
+              m[0]  * m[7] * m[14] +
+              m[4]  * m[2] * m[15] -
+              m[4]  * m[3] * m[14] -
+              m[12] * m[2] * m[7] +
+              m[12] * m[3] * m[6];
+
+    inv[10] = m[0]  * m[5] * m[15] -
+              m[0]  * m[7] * m[13] -
+              m[4]  * m[1] * m[15] +
+              m[4]  * m[3] * m[13] +
+              m[12] * m[1] * m[7] -
+              m[12] * m[3] * m[5];
+
+    inv[14] = -m[0]  * m[5] * m[14] +
+               m[0]  * m[6] * m[13] +
+               m[4]  * m[1] * m[14] -
+               m[4]  * m[2] * m[13] -
+               m[12] * m[1] * m[6] +
+               m[12] * m[2] * m[5];
+
+    inv[3] = -m[1] * m[6] * m[11] +
+              m[1] * m[7] * m[10] +
+              m[5] * m[2] * m[11] -
+              m[5] * m[3] * m[10] -
+              m[9] * m[2] * m[7] +
+              m[9] * m[3] * m[6];
+
+    inv[7] = m[0] * m[6] * m[11] -
+             m[0] * m[7] * m[10] -
+             m[4] * m[2] * m[11] +
+             m[4] * m[3] * m[10] +
+             m[8] * m[2] * m[7] -
+             m[8] * m[3] * m[6];
+
+    inv[11] = -m[0] * m[5] * m[11] +
+               m[0] * m[7] * m[9] +
+               m[4] * m[1] * m[11] -
+               m[4] * m[3] * m[9] -
+               m[8] * m[1] * m[7] +
+               m[8] * m[3] * m[5];
+
+    inv[15] = m[0] * m[5] * m[10] -
+              m[0] * m[6] * m[9] -
+              m[4] * m[1] * m[10] +
+              m[4] * m[2] * m[9] +
+              m[8] * m[1] * m[6] -
+              m[8] * m[2] * m[5];
+
+    det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+
+    if (det == 0)
+        return false;
+
+    det = 1.0 / det;
+
+    for (int i = 0; i < 16; i++)
+        MAT_ELEM_FLAT(matA, i) = inv[i] * det;
+
+    return true;
+}
+
+bool mat_inv_3x3(Matrix matA) {
+    double inv[9], det;
+
+    double *m = matA->data;
+    inv[0] =  m[4] * m[8] - m[5] * m[7];
+    inv[1] = -m[1] * m[8] + m[2] * m[7];
+    inv[2] =  m[1] * m[5] - m[2] * m[4];
+    inv[3] = -m[3] * m[8] + m[5] * m[6];
+    inv[4] =  m[0] * m[8] - m[2] * m[6];
+    inv[5] = -m[0] * m[5] + m[2] * m[3];
+    inv[6] =  m[3] * m[7] - m[4] * m[6];
+    inv[7] = -m[0] * m[7] + m[1] * m[6];
+    inv[8] =  m[0] * m[4] - m[1] * m[3];
+
+    det = m[0] * inv[0] + m[1] * inv[3] + m[2] * inv[6];
+
+    if (det == 0)
+        return false;
+
+    det = 1.0 / det;
+
+    for (int i = 0; i < 9; i++)
+        MAT_ELEM_FLAT(matA, i) = inv[i] * det;
+
+    return true;
+}
+
+Matrix mat_rotation_x(float rad) {
+    Matrix res = mat_new(3, 3);
+    float cosA = cos(rad);
+    float sinA = sin(rad);
+
+    MAT_ELEM(res, 0, 0) = 1.0f;
+    MAT_ELEM(res, 0, 1) = 0.0f;
+    MAT_ELEM(res, 0, 2) = 0.0f;
+
+    MAT_ELEM(res, 1, 0) = 0.0f;
+    MAT_ELEM(res, 1, 1) = cosA;
+    MAT_ELEM(res, 1, 2) = -sinA;
+
+    MAT_ELEM(res, 2, 0) = 0.0f;
+    MAT_ELEM(res, 2, 1) = sinA;
+    MAT_ELEM(res, 2, 2) = cosA;
+    return res;
+}
+
+Matrix mat_rotation_y(float rad) {
+    Matrix res = mat_new(3, 3);
+    float cosA = cos(rad);
+    float sinA = sin(rad);
+
+    MAT_ELEM(res, 0, 0) = cosA;
+    MAT_ELEM(res, 0, 1) = 0.0f;
+    MAT_ELEM(res, 0, 2) = sinA;
+
+    MAT_ELEM(res, 1, 0) = 0.0f;
+    MAT_ELEM(res, 1, 1) = 1.0f;
+    MAT_ELEM(res, 1, 2) = 0.0f;
+
+    MAT_ELEM(res, 2, 0) = -sinA;
+    MAT_ELEM(res, 2, 1) = 0.0f;
+    MAT_ELEM(res, 2, 2) = cosA;
+    return res;
+}
+
+Matrix mat_rotation_z(float rad) {
+    Matrix res = mat_new(3, 3);
+    float cosA = cos(rad);
+    float sinA = sin(rad);
+
+    MAT_ELEM(res, 0, 0) = cosA;
+    MAT_ELEM(res, 0, 1) = -sinA;
+    MAT_ELEM(res, 0, 2) = 0.0f;
+
+    MAT_ELEM(res, 1, 0) = sinA;
+    MAT_ELEM(res, 1, 1) = cosA;
+    MAT_ELEM(res, 1, 2) = 0.0f;
+
+    MAT_ELEM(res, 2, 0) = 0.0f;
+    MAT_ELEM(res, 2, 1) = 0.0f;
+    MAT_ELEM(res, 2, 2) = 1.0f;
+    return res;
+}
+
+void mat_print(Matrix matA) {
+    if (matA == NULL) return;
+    printf("Size (%d, %d):\n", matA->rows, matA->columns);
+    for (int i = 0; i < matA->rows; i++) {
+        for (int j = 0; j < matA->columns; j++) {
+            printf("%.3f, ", MAT_ELEM(matA, i, j));
+        }
+        printf("\n");
+    }
+}
+
+void mat_free(Matrix matA) {
+    if (matA == NULL) return;
+    free(matA->data);
+    free(matA);
+    matA = NULL;
+}
+
+void mat_from_array_free(Matrix matA) {
+    if (matA != NULL)
+        free(matA);
+}

--- a/app/src/ext/magnetometer_calibration/matrix.c
+++ b/app/src/ext/magnetometer_calibration/matrix.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "matrix.h"
 
 #include "stdlib.h"
@@ -37,7 +54,7 @@ Matrix mat_copy_submat(Matrix matA, const unsigned int frow, const unsigned int 
 }
 Matrix mat_from_array(const double *array, const unsigned int rows, const unsigned int columns) {
     Matrix res = malloc(sizeof(Matrix_t));
-    res->rows = columns;
+    res->rows = rows;
     res->columns = columns;
     res->data = array;
     return res;
@@ -175,7 +192,7 @@ void mat_orthogonalize(Matrix matA) {
     assert(matA->rows == matA->columns);
     for (int i = 1; i < matA->columns; i++) {
         Vector column = mat_copy_column(matA, i);
-        for (int j = 1; j < i; j++) {
+        for (int j = 0; j < i; j++) {
             Vector prevColumn =  mat_copy_column(matA, j);
             vec_multiply_scalar(prevColumn, vec_dot_product(prevColumn, column));
             vec_sub(column, prevColumn);
@@ -342,8 +359,9 @@ bool mat_inv_4x4(Matrix matA) {
 
     det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
 
-    if (det == 0)
-        return false;
+    if (fabs(det) < 1e-10) {
+      return false;
+      }
 
     det = 1.0 / det;
 
@@ -369,8 +387,9 @@ bool mat_inv_3x3(Matrix matA) {
 
     det = m[0] * inv[0] + m[1] * inv[3] + m[2] * inv[6];
 
-    if (det == 0)
-        return false;
+    if (fabs(det) < 1e-10) {
+      return false;
+      }
 
     det = 1.0 / det;
 
@@ -452,7 +471,6 @@ void mat_free(Matrix matA) {
     if (matA == NULL) return;
     free(matA->data);
     free(matA);
-    matA = NULL;
 }
 
 void mat_from_array_free(Matrix matA) {

--- a/app/src/ext/magnetometer_calibration/matrix.c
+++ b/app/src/ext/magnetometer_calibration/matrix.c
@@ -59,6 +59,14 @@ Matrix mat_from_array(const double *array, const unsigned int rows, const unsign
     res->data = array;
     return res;
 }
+
+
+
+
+
+
+
+
 void mat_replace(Matrix matA, Matrix matB) {
     free(matA->data);
     matA->rows = matB->rows;
@@ -97,7 +105,7 @@ void mat_fill(Matrix matA, double val) {
     }
 }
 void mat_fill_diag(Matrix matA, double val) {
-    assert(matA->rows == matA->rows);
+    assert(matA && matA->rows == matA->columns);
     for (int i = 0; i < matA->rows; i++)  {
         MAT_ELEM(matA, i, i) = val;
     }
@@ -229,7 +237,7 @@ Vector mat_linsolve_upperr_triang(Matrix R, Vector b) {
     assert(R->rows == R->columns);
 
     Vector solution = vec_new(b->size);
-    float back_substitute;
+    double back_substitute;
     for (int i = b->size - 1; i >= 0; i--) {
         back_substitute = 0;
         for (int j = i+1; j <= b->size - 1; j++) {

--- a/app/src/ext/magnetometer_calibration/matrix.h
+++ b/app/src/ext/magnetometer_calibration/matrix.h
@@ -1,0 +1,59 @@
+#ifndef COMPONENTS_GEOMETRY_MATRIX_H_
+#define COMPONENTS_GEOMETRY_MATRIX_H_
+
+#include "vector.h"
+
+#define MAT_ELEM(MAT, ROW, COLUMN) MAT->data[(COLUMN) + (ROW)*MAT->columns]
+#define MAT_ELEM_FLAT(MAT, ID) MAT->data[(ID)]
+
+#define MAT_TO_TABLE(MAT, STRUCT) for (int ITER = 0; ITER < 9; ITER++) {STRUCT[ITER] = MAT_ELEM_FLAT(MAT, ITER);}
+#define TABLE_TO_MAT(MAT, STRUCT) for (int ITER = 0; ITER < 9; ITER++) {MAT_ELEM_FLAT(MAT, ITER) = STRUCT[ITER];}
+
+typedef struct {
+    unsigned int rows;
+    unsigned int columns;
+    double * data;
+} Matrix_t, *Matrix;
+
+Matrix mat_new(const unsigned int rows, const unsigned int columns);
+Matrix mat_new_I(const unsigned int rowsColumns);
+Matrix mat_copy(Matrix matA);
+Matrix mat_copy_submat(Matrix matA, const unsigned int frow, const unsigned int fcolumn,
+                                    const unsigned int rows, const unsigned int columns);
+Matrix mat_from_array(const double *array, const unsigned int rows, const unsigned int columns);
+void mat_replace(Matrix matA, Matrix matB);
+
+Vector mat_copy_column(Matrix matA, const unsigned int column);
+void mat_paste_column(Matrix matA, Vector vecB, const unsigned int column);
+Vector mat_get_diag(Matrix matA);
+
+void mat_fill(Matrix matA, double val);
+void mat_fill_diag(Matrix matA, double val);
+void mat_rewrite(Matrix matA, Matrix matB);
+
+Matrix mat_multiply(Matrix matA, Matrix matB);
+void mat_multiply_vec3_into(Matrix matA, Vector vecB);
+Matrix mat_multiply_MMT(Matrix matA);
+Vector mat_multiply_vec(Matrix matA, Vector vecB);
+Vector vec_multiply_mat(Vector vecA, Matrix matB);
+void mat_add(Matrix matA, Matrix matB);
+void mat_sub(Matrix matA, Matrix matB);
+Matrix mat_transpose(Matrix matA);
+void mat_orthogonalize(Matrix matA);
+
+bool mat_is_upper_triang(Matrix matA, double tol);
+bool mat_check_nan(Matrix matA);
+
+Vector mat_linsolve_upperr_triang(Matrix R, Vector b);
+bool mat_inv_4x4(Matrix matA);
+bool mat_inv_3x3(Matrix matA);
+
+Matrix mat_rotation_x(float rad);
+Matrix mat_rotation_y(float rad);
+Matrix mat_rotation_z(float rad);
+
+void mat_print(Matrix matA);
+
+void mat_free(Matrix matA);
+void mat_from_array_free(Matrix matA);
+#endif  // COMPONENTS_GEOMETRY_MATRIX_H_

--- a/app/src/ext/magnetometer_calibration/matrix.h
+++ b/app/src/ext/magnetometer_calibration/matrix.h
@@ -1,5 +1,21 @@
-#ifndef COMPONENTS_GEOMETRY_MATRIX_H_
-#define COMPONENTS_GEOMETRY_MATRIX_H_
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include "vector.h"
 
@@ -56,4 +72,4 @@ void mat_print(Matrix matA);
 
 void mat_free(Matrix matA);
 void mat_from_array_free(Matrix matA);
-#endif  // COMPONENTS_GEOMETRY_MATRIX_H_
+

--- a/app/src/ext/magnetometer_calibration/matrix.h
+++ b/app/src/ext/magnetometer_calibration/matrix.h
@@ -72,4 +72,3 @@ void mat_print(Matrix matA);
 
 void mat_free(Matrix matA);
 void mat_from_array_free(Matrix matA);
-

--- a/app/src/ext/magnetometer_calibration/qr.c
+++ b/app/src/ext/magnetometer_calibration/qr.c
@@ -1,0 +1,35 @@
+#include "qr.h"
+
+#include "stdio.h"
+
+QR_t qr_decomposition(Matrix M) {
+    QR_t res;
+    res.Q = mat_new(M->rows, M->columns);
+    res.R = mat_new(M->rows, M->columns);
+
+    Vector currentColumn;
+    Vector currentUnitVector;
+    double currentDotProduct;
+    double norm;
+    for (int i = 0; i < M->columns; i++) {
+        currentColumn = mat_copy_column(M, i);
+        for (int j = 0; j < i; j++) {
+            currentUnitVector = mat_copy_column(res.Q, j);
+            currentDotProduct = vec_dot_product(currentUnitVector, currentColumn);
+            vec_multiply_scalar(currentUnitVector, currentDotProduct);
+            vec_sub(currentColumn, currentUnitVector);
+            vec_free(currentUnitVector);
+            MAT_ELEM(res.R, j, i) = currentDotProduct;
+        }
+        norm = vec_norm(currentColumn);
+        MAT_ELEM(res.R, i, i) = norm;
+        vec_normalize(currentColumn);
+        mat_paste_column(res.Q, currentColumn, i);
+        vec_free(currentColumn);
+    }
+    return res;
+}
+void qr_free(QR_t qr) {
+    mat_free(qr.Q);
+    mat_free(qr.R);
+}

--- a/app/src/ext/magnetometer_calibration/qr.c
+++ b/app/src/ext/magnetometer_calibration/qr.c
@@ -1,3 +1,21 @@
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
 #include "qr.h"
 
 #include "stdio.h"

--- a/app/src/ext/magnetometer_calibration/qr.h
+++ b/app/src/ext/magnetometer_calibration/qr.h
@@ -1,0 +1,15 @@
+#ifndef COMPONENTS_GEOMETRY_QR_H_
+#define COMPONENTS_GEOMETRY_QR_H_
+
+#include "matrix.h"
+#include "vector.h"
+
+typedef struct {
+    Matrix Q;
+    Matrix R;
+} QR_t;
+
+QR_t qr_decomposition(Matrix M);
+void qr_free(QR_t qr);
+
+#endif  // COMPONENTS_GEOMETRY_QR_H_

--- a/app/src/ext/magnetometer_calibration/qr.h
+++ b/app/src/ext/magnetometer_calibration/qr.h
@@ -1,5 +1,21 @@
-#ifndef COMPONENTS_GEOMETRY_QR_H_
-#define COMPONENTS_GEOMETRY_QR_H_
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include "matrix.h"
 #include "vector.h"
@@ -12,4 +28,4 @@ typedef struct {
 QR_t qr_decomposition(Matrix M);
 void qr_free(QR_t qr);
 
-#endif  // COMPONENTS_GEOMETRY_QR_H_
+

--- a/app/src/ext/magnetometer_calibration/sensor_calibration.c
+++ b/app/src/ext/magnetometer_calibration/sensor_calibration.c
@@ -17,9 +17,10 @@
 
 #include "sensor_calibration.h"
 
-#include "stdio.h"
-#include "math.h"
-#include "assert.h"
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+
 #include "ellipsoid_fit.h"
 #include "eigen.h"
 

--- a/app/src/ext/magnetometer_calibration/sensor_calibration.c
+++ b/app/src/ext/magnetometer_calibration/sensor_calibration.c
@@ -1,0 +1,140 @@
+#include "sensor_calibration.h"
+
+#include "stdio.h"
+#include "math.h"
+#include "assert.h"
+#include "ellipsoid_fit.h"
+#include "eigen.h"
+
+Matrix calib_ellipsoid_matrix(Vector coefA) {
+    Matrix res = mat_new(3, 3);
+    MAT_ELEM(res, 0, 0) = VEC_ELEM(coefA, 0);
+    MAT_ELEM(res, 0, 1) = VEC_ELEM(coefA, 5);
+    MAT_ELEM(res, 0, 2) = VEC_ELEM(coefA, 4);
+
+    MAT_ELEM(res, 1, 0) = VEC_ELEM(coefA, 5);
+    MAT_ELEM(res, 1, 1) = VEC_ELEM(coefA, 1);
+    MAT_ELEM(res, 1, 2) = VEC_ELEM(coefA, 3);
+
+    MAT_ELEM(res, 2, 0) = VEC_ELEM(coefA, 4);
+    MAT_ELEM(res, 2, 1) = VEC_ELEM(coefA, 3);
+    MAT_ELEM(res, 2, 2) = VEC_ELEM(coefA, 2);
+    return res;
+}
+
+Matrix calib_calibrate_rotation(Matrix ellipMat, Vector prq, double d) {
+    Eigen_t eig = eig_solve(ellipMat);
+    mat_orthogonalize(eig.eigenvectors);  // compensating inaccuracy
+    Matrix rotation = mat_transpose(eig.eigenvectors);
+    Matrix rotatedEllipMat = mat_multiply(rotation, ellipMat);
+    Matrix diagonizedEllipMat = mat_multiply(rotatedEllipMat, eig.eigenvectors);
+    mat_free(rotatedEllipMat);
+    Vector rotPrq = vec_multiply_mat(prq, eig.eigenvectors);
+    double a_ = MAT_ELEM(diagonizedEllipMat, 0, 0);
+    double b_ = MAT_ELEM(diagonizedEllipMat, 1, 1);
+    double c_ = MAT_ELEM(diagonizedEllipMat, 2, 2);
+    mat_free(diagonizedEllipMat);
+    double p_ = VEC_ELEM(rotPrq, 0);
+    double q_ = VEC_ELEM(rotPrq, 1);
+    double r_ = VEC_ELEM(rotPrq, 2);
+    vec_free(rotPrq);
+    Matrix gain = mat_new(3, 3);
+    MAT_ELEM(gain , 0, 0) = 1/sqrt((p_*p_)/(a_*a_) + (q_*q_)/(a_*b_) + (r_*r_)/(a_*c_) - d/a_);
+    MAT_ELEM(gain , 1, 1) = 1/sqrt((p_*p_)/(a_*b_) + (q_*q_)/(b_*b_) + (r_*r_)/(b_*c_) - d/b_);
+    MAT_ELEM(gain , 2, 2) = 1/sqrt((p_*p_)/(a_*c_) + (q_*q_)/(b_*c_) + (r_*r_)/(c_*c_) - d/c_);
+    Matrix gain_Rotation = mat_multiply(gain, rotation);
+    Matrix res = mat_multiply(eig.eigenvectors, gain_Rotation);
+    eig_free(eig);
+    mat_free(gain_Rotation);
+    mat_free(gain);
+    mat_free(rotation);
+    return res;
+}
+
+Vector calib_calibrate_offset(Matrix ellipMat, Vector prq) {
+    mat_inv_3x3(ellipMat);
+    Vector res = mat_multiply_vec(ellipMat, prq);
+    vec_negate(res);
+    return res;
+}
+
+Callibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z) {
+    Callibration_t res;
+    res.offset = (Vector)0;
+    res.transform = (Matrix)0;
+    if (x->size < 6) return res;  //needs at least 6 samples to fit an ellipsoid, though in real use you want far more.
+    Ellipsoid_t ellip = ellipsoid_fit(x, y, z);
+    Matrix M = calib_ellipsoid_matrix(ellip.coefA);
+    Vector prq = vec_copy_subvec(ellip.coefB, 0, 3);
+    double d = ellip.coefB->data[3];
+    ellipsoid_free(ellip);
+    res.transform = calib_calibrate_rotation(M, prq, d);
+    res.offset = calib_calibrate_offset(M, prq);
+    mat_free(M);
+    vec_free(prq);
+    return res;
+}
+
+bool calib_calibration_success(Callibration_t calib) {
+    return !(vec_check_nan(calib.offset) || mat_check_nan(calib.transform));
+}
+
+//ie
+//offset != NULL
+//transform != NULL
+
+
+
+
+void calib_calibrate_multiple_points(Callibration_t calib, Vector x, Vector y, Vector z) {
+    assert(x->size == y->size);
+    assert(x->size == z->size);
+
+    for (int i = 0; i < x->size; i++) {
+        VEC_ELEM(x, i) = VEC_ELEM(x, i) - VEC_ELEM(calib.offset, 0);
+        VEC_ELEM(y, i) = VEC_ELEM(y, i) - VEC_ELEM(calib.offset, 1);
+        VEC_ELEM(z, i) = VEC_ELEM(z, i) - VEC_ELEM(calib.offset, 2);
+    }
+    double tempX, tempY;
+    for (int i = 0; i < x->size; i++) {
+        tempX = VEC_ELEM(x, i);
+        tempY = VEC_ELEM(y, i);
+
+        VEC_ELEM(x, i) = tempX * MAT_ELEM(calib.transform, 0, 0) + tempY * MAT_ELEM(calib.transform, 0, 1) +
+                        VEC_ELEM(z, i) * MAT_ELEM(calib.transform, 0, 2);
+        VEC_ELEM(y, i) = tempX * MAT_ELEM(calib.transform, 1, 0) + tempY * MAT_ELEM(calib.transform, 1, 1) +
+                        VEC_ELEM(z, i) * MAT_ELEM(calib.transform, 1, 2);
+        VEC_ELEM(z, i) = tempX * MAT_ELEM(calib.transform, 2, 0) + tempY * MAT_ELEM(calib.transform, 2, 1) +
+                        VEC_ELEM(z, i) * MAT_ELEM(calib.transform, 2, 2);
+    }
+}
+
+void calib_calibrate_point(Callibration_t calib, Vector point) {
+    vec_sub(point, calib.offset);
+    mat_multiply_vec3_into(calib.transform, point);
+}
+
+double square_distance_variance(Vector x, Vector y, Vector z) {
+    // var = sum((d - mean(d))^2)/(n-1)
+    assert(x->size == y->size);
+    assert(x->size == z->size);
+    assert(x->size > 1);
+    double mean = 0;
+    double res = 0;
+    double temp;
+    for (int i = 0; i < x->size; i++) {
+        mean += sqrt(VEC_ELEM(x, i) * VEC_ELEM(x, i) + VEC_ELEM(y, i) * VEC_ELEM(y, i) + VEC_ELEM(z, i) * VEC_ELEM(z, i));
+    }
+    mean /= x->size;
+    for (int i = 0; i < x->size; i++) {
+        temp = sqrt(VEC_ELEM(x, i) * VEC_ELEM(x, i) + VEC_ELEM(y, i) * VEC_ELEM(y, i) + VEC_ELEM(z, i) * VEC_ELEM(z, i)) - mean;
+        res += temp * temp;
+    }
+    res = res/(x->size-1);
+    return res;
+}
+
+void calib_free(Callibration_t calibA) {
+    vec_free(calibA.offset);
+    mat_free(calibA.transform);
+}

--- a/app/src/ext/magnetometer_calibration/sensor_calibration.c
+++ b/app/src/ext/magnetometer_calibration/sensor_calibration.c
@@ -1,3 +1,20 @@
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "sensor_calibration.h"
 
 #include "stdio.h"
@@ -6,7 +23,7 @@
 #include "ellipsoid_fit.h"
 #include "eigen.h"
 
-Matrix calib_ellipsoid_matrix(Vector coefA) {
+static Matrix calib_ellipsoid_matrix(Vector coefA) {
     Matrix res = mat_new(3, 3);
     MAT_ELEM(res, 0, 0) = VEC_ELEM(coefA, 0);
     MAT_ELEM(res, 0, 1) = VEC_ELEM(coefA, 5);
@@ -22,7 +39,7 @@ Matrix calib_ellipsoid_matrix(Vector coefA) {
     return res;
 }
 
-Matrix calib_calibrate_rotation(Matrix ellipMat, Vector prq, double d) {
+static Matrix calib_calibrate_rotation(Matrix ellipMat, Vector prq, double d) {
     Eigen_t eig = eig_solve(ellipMat);
     mat_orthogonalize(eig.eigenvectors);  // compensating inaccuracy
     Matrix rotation = mat_transpose(eig.eigenvectors);
@@ -51,15 +68,15 @@ Matrix calib_calibrate_rotation(Matrix ellipMat, Vector prq, double d) {
     return res;
 }
 
-Vector calib_calibrate_offset(Matrix ellipMat, Vector prq) {
+static Vector calib_calibrate_offset(Matrix ellipMat, Vector prq) {
     mat_inv_3x3(ellipMat);
     Vector res = mat_multiply_vec(ellipMat, prq);
     vec_negate(res);
     return res;
 }
 
-Callibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z) {
-    Callibration_t res;
+Calibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z) {
+    Calibration_t res;
     res.offset = (Vector)0;
     res.transform = (Matrix)0;
     if (x->size < 6) return res;  //needs at least 6 samples to fit an ellipsoid, though in real use you want far more.
@@ -75,7 +92,7 @@ Callibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z) {
     return res;
 }
 
-bool calib_calibration_success(Callibration_t calib) {
+bool calib_calibration_success(Calibration_t calib) {
     return !(vec_check_nan(calib.offset) || mat_check_nan(calib.transform));
 }
 
@@ -86,7 +103,7 @@ bool calib_calibration_success(Callibration_t calib) {
 
 
 
-void calib_calibrate_multiple_points(Callibration_t calib, Vector x, Vector y, Vector z) {
+void calib_calibrate_multiple_points(Calibration_t calib, Vector x, Vector y, Vector z) {
     assert(x->size == y->size);
     assert(x->size == z->size);
 
@@ -109,7 +126,7 @@ void calib_calibrate_multiple_points(Callibration_t calib, Vector x, Vector y, V
     }
 }
 
-void calib_calibrate_point(Callibration_t calib, Vector point) {
+void calib_calibrate_point(Calibration_t calib, Vector point) {
     vec_sub(point, calib.offset);
     mat_multiply_vec3_into(calib.transform, point);
 }
@@ -134,7 +151,7 @@ double square_distance_variance(Vector x, Vector y, Vector z) {
     return res;
 }
 
-void calib_free(Callibration_t calibA) {
+void calib_free(Calibration_t calibA) {
     vec_free(calibA.offset);
     mat_free(calibA.transform);
 }

--- a/app/src/ext/magnetometer_calibration/sensor_calibration.h
+++ b/app/src/ext/magnetometer_calibration/sensor_calibration.h
@@ -1,0 +1,20 @@
+#ifndef COMPONENTS_GEOMETRY_SENSOR_CALIBRATION_H_
+#define COMPONENTS_GEOMETRY_SENSOR_CALIBRATION_H_
+
+#include "stdbool.h"
+#include "matrix.h"
+#include "vector.h"
+
+typedef struct {
+    Vector offset;
+    Matrix transform;
+} Callibration_t;
+
+Callibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z);
+bool calib_calibration_success(Callibration_t calib);
+void calib_calibrate_multiple_points(Callibration_t calib, Vector x, Vector y, Vector z);
+void calib_calibrate_point(Callibration_t calib, Vector point);
+double square_distance_variance(Vector x, Vector y, Vector z);
+void calib_free(Callibration_t calibA);
+
+#endif  // COMPONENTS_GEOMETRY_SENSOR_CALIBRATION_H_

--- a/app/src/ext/magnetometer_calibration/sensor_calibration.h
+++ b/app/src/ext/magnetometer_calibration/sensor_calibration.h
@@ -1,5 +1,21 @@
-#ifndef COMPONENTS_GEOMETRY_SENSOR_CALIBRATION_H_
-#define COMPONENTS_GEOMETRY_SENSOR_CALIBRATION_H_
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include "stdbool.h"
 #include "matrix.h"
@@ -8,13 +24,11 @@
 typedef struct {
     Vector offset;
     Matrix transform;
-} Callibration_t;
+} Calibration_t;
 
-Callibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z);
-bool calib_calibration_success(Callibration_t calib);
-void calib_calibrate_multiple_points(Callibration_t calib, Vector x, Vector y, Vector z);
-void calib_calibrate_point(Callibration_t calib, Vector point);
+Calibration_t calib_calibrate_sensor(Vector x, Vector y, Vector z);
+bool calib_calibration_success(Calibration_t calib);
+void calib_calibrate_multiple_points(Calibration_t calib, Vector x, Vector y, Vector z);
+void calib_calibrate_point(Calibration_t calib, Vector point);
 double square_distance_variance(Vector x, Vector y, Vector z);
-void calib_free(Callibration_t calibA);
-
-#endif  // COMPONENTS_GEOMETRY_SENSOR_CALIBRATION_H_
+void calib_free(Calibration_t calibA);

--- a/app/src/ext/magnetometer_calibration/sensor_calibration.h
+++ b/app/src/ext/magnetometer_calibration/sensor_calibration.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "stdbool.h"
+#include <stdbool.h>
 #include "matrix.h"
 #include "vector.h"
 

--- a/app/src/ext/magnetometer_calibration/vector.c
+++ b/app/src/ext/magnetometer_calibration/vector.c
@@ -1,0 +1,195 @@
+#include "vector.h"
+
+#include "assert.h"
+#include "stdlib.h"
+#include "stdio.h"
+#include "math.h"
+
+Vector vec_new(unsigned int size) {
+    Vector res = malloc(sizeof(Vector_t));
+    res->size = size;
+    res->data = calloc(size, sizeof(double));
+    return res;
+}
+
+Vector vec_from_array(const double *array, unsigned int size) {
+    Vector res = malloc(sizeof(Vector_t));
+    res->size = size;
+    res->data = array;
+    return res;
+}
+
+Vector vec_copy(Vector vecA) {
+    Vector res = vec_new(vecA->size);
+    for (int i = 0; i < vecA->size; i++) {
+        VEC_ELEM(res, i) = VEC_ELEM(vecA, i);
+    }
+    return res;
+}
+
+Vector vec_copy_subvec(Vector vecA, unsigned int felem, unsigned int elems) {
+    assert(vecA->size >= felem + elems);
+    Vector res = vec_new(elems);
+    for (int i = 0; i < elems; i++) {
+        VEC_ELEM(res, i) = VEC_ELEM(vecA, felem + i);
+    }
+    return res;
+}
+
+void vec_replace(Vector vecA, Vector vecB) {
+    free(vecA->data);
+    vecA->size = vecB->size;
+    vecA->data = vecB->data;
+    free(vecB);
+}
+
+void vec_fill(Vector vecA, double val) {
+    for (int i = 0; i < vecA->size; i++) {
+        VEC_ELEM(vecA, i) = val;
+    }
+}
+
+double vec_dot_product(Vector vecA, Vector vecB) {
+    assert(vecA->size == vecB->size);
+    double res = 0;
+    for (int i = 0; i < vecA->size; i++) {
+        res += VEC_ELEM(vecA, i) * VEC_ELEM(vecB, i);
+    }
+    return res;
+}
+
+Vector vec_cross_product(Vector vecA, Vector vecB) {
+    assert(vecA->size == 3 && vecB->size == 3);
+    Vector res = vec_new(3);
+
+    VEC_ELEM(res, 0) = VEC_ELEM(vecA, 1) * VEC_ELEM(vecB, 2) - VEC_ELEM(vecA, 2) * VEC_ELEM(vecB, 1);
+    VEC_ELEM(res, 1) = VEC_ELEM(vecA, 2) * VEC_ELEM(vecB, 0) - VEC_ELEM(vecA, 0) * VEC_ELEM(vecB, 2);
+    VEC_ELEM(res, 2) = VEC_ELEM(vecA, 0) * VEC_ELEM(vecB, 1) - VEC_ELEM(vecA, 1) * VEC_ELEM(vecB, 0);
+
+    return res;
+}
+
+void vec_multiply_scalar(Vector vecA, double val) {
+    for (int i = 0; i < vecA->size; i++) {
+        VEC_ELEM(vecA, i) *= val;
+    }
+}
+void vec_add(Vector vecA, Vector vecB) {
+    assert(vecA->size == vecB->size);
+    for (int i = 0; i < vecA->size; i++) {
+        VEC_ELEM(vecA, i) += VEC_ELEM(vecB, i);
+    }
+}
+void vec_sub(Vector vecA, Vector vecB) {
+    assert(vecA->size == vecB->size);
+    for (int i = 0; i < vecA->size; i++) {
+        VEC_ELEM(vecA, i) -= VEC_ELEM(vecB, i);
+    }
+}
+double vec_norm_square(Vector vecA) {
+    double res = 0;
+    for (int i = 0; i < vecA->size; i++) {
+        res += VEC_ELEM(vecA, i) * VEC_ELEM(vecA, i);
+    }
+    return res;
+}
+double vec_norm(Vector vecA) {
+    return sqrt(vec_norm_square(vecA));
+}
+float vec_angle_between(Vector vecA, Vector vecB) {
+    return acos((VEC_X(vecA) * VEC_X(vecB) + VEC_Y(vecA) * VEC_Y(vecB) + VEC_Z(vecA) * VEC_Z(vecB)) / sqrt(
+            (VEC_X(vecA) * VEC_X(vecA) + VEC_Y(vecA) * VEC_Y(vecA) + VEC_Z(vecA) * VEC_Z(vecA)) *
+            (VEC_X(vecB) * VEC_X(vecB) + VEC_Y(vecB) * VEC_Y(vecB) + VEC_Z(vecB) * VEC_Z(vecB))));
+}
+
+float vec_angle_between_2D(Vector vecA, Vector vecB) {
+    return atan2(VEC_Y(vecA), VEC_X(vecA)) - atan2(VEC_Y(vecB), VEC_X(vecB));
+}
+
+bool vec_normalize(Vector vecA) {
+    double norm = vec_norm(vecA);
+    if (norm == 0) return false;
+    else
+        vec_multiply_scalar(vecA, 1/norm);
+    return true;
+}
+
+void vec_negate(Vector vecA) {
+    for (int i = 0; i < vecA->size; i++) {
+        VEC_ELEM(vecA, i) = -VEC_ELEM(vecA, i);
+    }
+}
+
+void vec_rotate_x(Vector vec, float rad) {
+    double cosA = cos(rad);
+    double sinA = sin(rad);
+
+    double temp = VEC_ELEM(vec, 1);
+    VEC_ELEM(vec, 1) = cosA * temp - sinA * VEC_ELEM(vec, 2);
+    VEC_ELEM(vec, 2) = cosA * temp - sinA * VEC_ELEM(vec, 2);
+}
+
+void vec_rotate_y(Vector vec, float rad) {
+    double cosA = cos(rad);
+    double sinA = sin(rad);
+
+    double temp = VEC_ELEM(vec, 0);
+
+    VEC_ELEM(vec, 0) = cosA * temp + sinA * VEC_ELEM(vec, 2);
+    VEC_ELEM(vec, 2) = -sinA * temp + cosA * VEC_ELEM(vec, 2);
+}
+
+void vec_rotate_z(Vector vec, float rad) {
+    double cosA = cos(rad);
+    double sinA = sin(rad);
+
+    double temp = VEC_ELEM(vec, 0);
+
+    VEC_ELEM(vec, 0) = cosA * temp - sinA * VEC_ELEM(vec, 1);
+    VEC_ELEM(vec, 1) = sinA * temp + cosA * VEC_ELEM(vec, 1);
+}
+
+bool vec_contains(Vector vecA, double val, double tol) {
+    for (int i = 0; i < vecA->size; i++) {
+        if (fabs(VEC_ELEM(vecA, i)) > tol)
+            return true;
+    }
+    return false;
+}
+
+bool vec_equal(Vector vecA, Vector vecB, double tol) {
+    if (vecA->size != vecB->size) return false;
+    for (int i = 0; i < vecA->size; i++) {
+        if (fabs(VEC_ELEM(vecA, i) - VEC_ELEM(vecB, i)) > tol)
+            return false;
+    }
+    return true;
+}
+
+bool vec_check_nan(Vector vecA) {
+    for (int i = 0; i < vecA->size; i++) {
+        if (VEC_ELEM(vecA, i) != VEC_ELEM(vecA, i))
+            return true;
+    }
+    return false;
+}
+
+void vec_print(Vector vecA) {
+    if (vecA == NULL) return;
+    printf("[");
+    for (int i = 0; i < vecA->size; i++) {
+        printf("%.10f, ", VEC_ELEM(vecA, i));
+    }
+    printf("]\n");
+}
+
+void vec_free(Vector vecA) {
+    if (vecA == NULL) return;
+    if (vecA->data != NULL)
+        free(vecA->data);
+    free(vecA);
+}
+void vec_from_array_free(Vector vecA) {
+    if (vecA != NULL)
+        free(vecA);
+}

--- a/app/src/ext/magnetometer_calibration/vector.c
+++ b/app/src/ext/magnetometer_calibration/vector.c
@@ -1,9 +1,26 @@
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "vector.h"
 
-#include "assert.h"
-#include "stdlib.h"
-#include "stdio.h"
-#include "math.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
 
 Vector vec_new(unsigned int size) {
     Vector res = malloc(sizeof(Vector_t));
@@ -126,7 +143,7 @@ void vec_rotate_x(Vector vec, float rad) {
 
     double temp = VEC_ELEM(vec, 1);
     VEC_ELEM(vec, 1) = cosA * temp - sinA * VEC_ELEM(vec, 2);
-    VEC_ELEM(vec, 2) = cosA * temp - sinA * VEC_ELEM(vec, 2);
+    VEC_ELEM(vec, 2) = sinA * temp + cosA * VEC_ELEM(vec, 2);
 }
 
 void vec_rotate_y(Vector vec, float rad) {
@@ -151,7 +168,7 @@ void vec_rotate_z(Vector vec, float rad) {
 
 bool vec_contains(Vector vecA, double val, double tol) {
     for (int i = 0; i < vecA->size; i++) {
-        if (fabs(VEC_ELEM(vecA, i)) > tol)
+        if (fabs(VEC_ELEM(vecA, i) - val) <= tol)
             return true;
     }
     return false;

--- a/app/src/ext/magnetometer_calibration/vector.h
+++ b/app/src/ext/magnetometer_calibration/vector.h
@@ -1,0 +1,52 @@
+#ifndef COMPONENTS_GEOMETRY_VECTOR_H_
+#define COMPONENTS_GEOMETRY_VECTOR_H_
+
+#include "stdbool.h"
+
+#define VEC_ELEM(VEC, ID) VEC->data[ID]
+#define VEC_X(VEC) VEC->data[0]
+#define VEC_Y(VEC) VEC->data[1]
+#define VEC_Z(VEC) VEC->data[2]
+
+#define VEC_TO_TABLE(VEC, STRUCT) for (int ITER = 0; ITER < 3; ITER++) {STRUCT[ITER] = VEC_ELEM(VEC, ITER);}
+#define TABLE_TO_VEC(VEC, STRUCT) for (int ITER = 0; ITER < 3; ITER++) {VEC_ELEM(VEC, ITER) = STRUCT[ITER];}
+
+typedef struct {
+    unsigned int size;
+    double *data;
+} Vector_t, *Vector;
+
+Vector vec_new(unsigned int size);
+Vector vec_from_array(const double *array, unsigned int size);
+Vector vec_copy(Vector vecA);
+Vector vec_copy_subvec(Vector vecA, unsigned int felem, unsigned int elems);
+void vec_replace(Vector vecA, Vector vecB);
+
+void vec_fill(Vector vecA, double val);
+
+double vec_dot_product(Vector vecA, Vector vecB);
+Vector vec_cross_product(Vector vecA, Vector vecB);
+void vec_multiply_scalar(Vector vecA, double val);
+void vec_add(Vector vecA, Vector vecB);
+void vec_sub(Vector vecA, Vector vecB);
+double vec_norm_square(Vector vecA);
+double vec_norm(Vector vecA);
+
+float vec_angle_between(Vector vecA, Vector vecB);
+float vec_angle_between_2D(Vector vecA, Vector vecB);
+
+bool vec_normalize(Vector vecA);
+void vec_negate(Vector vecA);
+void vec_rotate_x(Vector vec, float rad);
+void vec_rotate_y(Vector vec, float rad);
+void vec_rotate_z(Vector vec, float rad);
+
+bool vec_contains(Vector vecA, double val, double tol);
+bool vec_equal(Vector vecA, Vector vecB, double tol);
+bool vec_check_nan(Vector vecA);
+
+void vec_print(Vector vecA);
+
+void vec_free(Vector vecA);
+void vec_from_array_free(Vector vecA);
+#endif  // COMPONENTS_GEOMETRY_VECTOR_H_

--- a/app/src/ext/magnetometer_calibration/vector.h
+++ b/app/src/ext/magnetometer_calibration/vector.h
@@ -1,7 +1,23 @@
-#ifndef COMPONENTS_GEOMETRY_VECTOR_H_
-#define COMPONENTS_GEOMETRY_VECTOR_H_
+/*
+ * This file is part of ZSWatch project <https://github.com/zswatch/>.
+ * Copyright (c) 2025 ZSWatch Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
-#include "stdbool.h"
+#pragma once
+
+#include <stdbool.h>
 
 #define VEC_ELEM(VEC, ID) VEC->data[ID]
 #define VEC_X(VEC) VEC->data[0]
@@ -49,4 +65,3 @@ void vec_print(Vector vecA);
 
 void vec_free(Vector vecA);
 void vec_from_array_free(Vector vecA);
-#endif  // COMPONENTS_GEOMETRY_VECTOR_H_

--- a/app/src/sensors/zsw_magnetometer.c
+++ b/app/src/sensors/zsw_magnetometer.c
@@ -45,16 +45,14 @@ LOG_MODULE_REGISTER(zsw_magnetometer, CONFIG_ZSW_SENSORS_LOG_LEVEL);
 #define SETTINGS_KEY_CALIB              "calibr"
 #define SETTINGS_MAGN_CALIB             SETTINGS_NAME_MAGN "/" SETTINGS_KEY_CALIB
 
-#define CONFIG_BOARD_NATIVE_SIM
-
 typedef struct {
-    float offset_x; //for hard correction
+    float offset_x;
     float offset_y;
     float offset_z;
-    float transform[3][3]; //for soft correction
+    float transform[3][3];
 } magn_calib_data_t;
 
-static magn_calib_data_t calibration_data = { //transform needs an identity default
+static magn_calib_data_t calibration_data = {
     .transform = {
         {1.0f, 0.0f, 0.0f},
         {0.0f, 1.0f, 0.0f},
@@ -63,7 +61,7 @@ static magn_calib_data_t calibration_data = { //transform needs an identity defa
 };
 
 static void copy_offset_and_matrix_to_calibration_data(
-    const Callibration_t calib);
+    const Calibration_t calib);
 
 static double last_x;
 static double last_y;
@@ -76,10 +74,7 @@ static double min_y;
 static double min_z;
 static bool getting_data;
 static bool calibration_ready;
-
-#ifdef CONFIG_BOARD_NATIVE_SIM
-static int dummy_count;
-#endif
+static bool recalibration_required;
 
 #define CAL_MIN_RANGE 20.0 // Axis range required for 100% progress; tune on hardware.
 
@@ -90,8 +85,14 @@ static double cal_y[CAL_SAMPLE_MAX];
 static double cal_z[CAL_SAMPLE_MAX];
 static int cal_sample_count;
 
+static int cal_progress_x;
+static int cal_progress_y;
+static int cal_progress_z;
 
-
+bool zsw_magnetometer_recalibration_required(void)
+{
+    return recalibration_required;
+}
 
 
 static int axis_progress(double min, double max)
@@ -102,52 +103,6 @@ static int axis_progress(double min, double max)
     return MIN(progress, 100);
 }
 
-//dummy parametric ellipsoid calibration data as have no hardware for data gathering
-
-#define DUMMY_N 80
-
-double dummy_x[DUMMY_N], dummy_y[DUMMY_N], dummy_z[DUMMY_N];
-
-static void debug_fill_dummy_samples(double x[], double y[], double z[])
-{
-    const double ox = 8.0, oy = -5.0, oz = 3.0;
-    const double ax = 40.0, by = 25.0, cz = 15.0;
-
-
-    /*
-
-    I verified the ellipsoid fitting using synthetic magnetometer data generated from a known ellipsoid with hard-iron offsets (8, -5, 3) and axis radii (40, 25, 15)
-    The recovered hard-iron offsets matched the synthetic offsets
-    The recovered scale factors matched the expected inverse axis scaling (1/40, 1/25, 1/15), transforming the ellipsoid back into a unit sphere
-
-
-
-
-    */
-
-
-
-    for (int i = 0; i < DUMMY_N; i++) {
-        double t = (2.0 * M_PI * i) / DUMMY_N;
-        double p = M_PI * ((i * 37) % DUMMY_N) / DUMMY_N;
-
-        x[i] = ox + ax * cos(t) * sin(p);
-        y[i] = oy + by * sin(t) * sin(p);
-        z[i] = oz + cz * cos(p);
-    }
-
-    //for (int i = 0; i < DUMMY_N; i++) {
-    //printf("%f\n", dummy_x[i]);
-    //}
-      //ok so below shows the same sample format as the library used
-      /*
-      8.000000
-      47.600286
-      ...
-
-      */
-
-}
 
 static void zbus_periodic_slow_callback(const struct zbus_channel *chan);
 
@@ -195,7 +150,6 @@ static void lis2mdl_trigger_handler(const struct device *dev,
     last_y = sensor_value_to_float(&magn[0]) * 10;
     last_z = sensor_value_to_float(&magn[2]) * 10;
 
-    /* gathering data for subsequent calibration */
     if (getting_data) {
         if (last_x < min_x) {
             min_x = last_x;
@@ -218,34 +172,30 @@ static void lis2mdl_trigger_handler(const struct device *dev,
             max_z = last_z;
         }
 
-        if (cal_sample_count < CAL_SAMPLE_MAX) {  //storing real data
+        if (cal_sample_count < CAL_SAMPLE_MAX) {
             cal_x[cal_sample_count] = last_x;
             cal_y[cal_sample_count] = last_y;
             cal_z[cal_sample_count] = last_z;
             cal_sample_count++;
         }
 
-
-
-        int px = axis_progress(min_x, max_x);
-        int py = axis_progress(min_y, max_y);
-        int pz = axis_progress(min_z, max_z);
-
-        compass_ui_set_calibration_progress(px, py, pz);
+        cal_progress_x = axis_progress(min_x, max_x);
+        cal_progress_y = axis_progress(min_y, max_y);
+        cal_progress_z = axis_progress(min_z, max_z);
 
         calibration_ready =
-        (px == 100) &&
-        (py == 100) &&
-        (pz == 100);
+            (cal_progress_x == 100) &&
+            (cal_progress_y == 100) &&
+            (cal_progress_z == 100);
 
     }
 
-    /* apply last known Hard-iron correction */
+
     const double x = last_x - calibration_data.offset_x;
     const double y = last_y - calibration_data.offset_y;
     const double z = last_z - calibration_data.offset_z;
 
-    /* apply last known Soft-iron correction */
+
     last_x =
         calibration_data.transform[0][0] * x +
         calibration_data.transform[0][1] * y +
@@ -267,14 +217,38 @@ static void lis2mdl_trigger_handler(const struct device *dev,
 
 
 
+int zsw_magnetometer_get_calibration_progress(int *px, int *py, int *pz)
+  {
+    if (!px || !py || !pz) {
+        return -EINVAL;
+    }
+
+    *px = cal_progress_x;
+    *py = cal_progress_y;
+    *pz = cal_progress_z;
+
+    return 0;
+  }
+
+
+
 static int magn_cal_load(const char *p_key, size_t len,
                          settings_read_cb read_cb, void *p_cb_arg, void *p_param)
 {
     ARG_UNUSED(p_key);
 
     if (len != sizeof(magn_calib_data_t)) {
-        LOG_ERR("Invalid length of magn calibration data");
-        return -EINVAL;
+        LOG_ERR("Ignoring old magnetometer calibration data. Recalibration required.");
+
+        calibration_data.offset_x = 0.0f;
+        calibration_data.offset_y = 0.0f;
+        calibration_data.offset_z = 0.0f;
+
+        recalibration_required = true;
+
+        return 0;
+
+
     }
 
     if (read_cb(p_cb_arg, &calibration_data, len) != sizeof(magn_calib_data_t)) {
@@ -357,20 +331,28 @@ int zsw_magnetometer_set_enable(bool enabled)
     return 0;
 }
 
+
+
+int zsw_magnetometer_cancel_calibration(void)
+{
+    getting_data = false;
+    calibration_ready = false;
+    cal_sample_count = 0;
+
+    return 0;
+}
+
+
 int zsw_magnetometer_gather_data(void)
 {
     calibration_ready = false;
     cal_sample_count = 0;
 
-    //commented out as on simulator
-    /*
+
+
     if (!device_is_ready(magnetometer)) {
         return -ENODEV;
     }
-    */
-    #ifdef CONFIG_BOARD_NATIVE_SIM
-    dummy_count = 0;
-    #endif
 
     max_x = -100000;
     max_y = -100000;
@@ -379,138 +361,47 @@ int zsw_magnetometer_gather_data(void)
     min_y = 100000;
     min_z = 100000;
 
-    getting_data = true;  //trigger data gathering part of lis2mdl_trigger_handler
+    getting_data = true;
 
     return 0;
 }
 
-bool zsw_magnetometer_calibration_ready(void) //exercising the whole UI flow without hardware
+bool zsw_magnetometer_calibration_ready(void)
 {
-#ifdef CONFIG_BOARD_NATIVE_SIM
-
-    dummy_count++;
-    return dummy_count > 20;   // ready after ~20 timer ticks
-
-#else
     return calibration_ready;
-#endif
+
 }
 
-int zsw_magnetometer_compute_compensation(void)   //this used to be called zsw_magnetometer_stop_calibration
+int zsw_magnetometer_compute_compensation(void)
 {
 
-
-    //calibration_data.offset_x = (max_x + min_x) / 2;  //old simple method
-    //calibration_data.offset_y = (max_y + min_y) / 2;
-    //calibration_data.offset_z = (max_z + min_z) / 2;
-
-
-
-
-
-
-
-    //return 1;
-
-    //commented out as on simulator
-    //if (!device_is_ready(magnetometer)) {
-        //return -ENODEV;
-    //}
+    if (!device_is_ready(magnetometer)) {
+        return -ENODEV;
+    }
 
     getting_data = false;
-
-    //following hard and soft calibration method from https://github.com/michal34512/Magnetometer-calibration
-    //LOG_INF("dummy: creating vectors");
-
-    //debug_fill_dummy_samples(dummy_x, dummy_y, dummy_z);
-
-    //Vector vx = vec_from_array(dummy_x, DUMMY_N);
-    //Vector vy = vec_from_array(dummy_y, DUMMY_N);
-    //Vector vz = vec_from_array(dummy_z, DUMMY_N);
-
-
-
-
-    //running on real data
-
 
     Vector vx = vec_from_array(cal_x, cal_sample_count);
     Vector vy = vec_from_array(cal_y, cal_sample_count);
     Vector vz = vec_from_array(cal_z, cal_sample_count);
 
-    LOG_INF("Data: running fit");
-    Callibration_t calib = calib_calibrate_sensor(vx, vy, vz);
+    Calibration_t calib = calib_calibrate_sensor(vx, vy, vz);
 
-
-
-
-
-
-    /*
-    //checking the end result of the compensation:
-
-    <pre>[00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: Calibration successful
-    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: Offset: 8.000 -5.000 3.000 //stored but not applied hard iron cal paramaters
-    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: Transform:
-    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: 0.025 0.000 0.000  //stored but not applied soft iron cal parameters
-    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: 0.000 0.040 0.000
-    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: 0.000 0.000 0.067
-    </pre>
-
-
-
-
-    //soft iron ie distortion
-    The corrected points should lie on a sphere.
-
-
-
-    //hard iron re offset
-    The corrected points should be centred approximately at (0, 0, 0)
-
-
-
-
-
-
-    */
-
-
-    LOG_INF("dummy: success=%d", calib_calibration_success(calib));
     if (!calib_calibration_success(calib)) {
         calib_free(calib);
         return -EINVAL;
     }
 
-    LOG_INF("dummy: copying result");
     copy_offset_and_matrix_to_calibration_data(calib);
 
-    LOG_INF("dummy: saving settings");
-    settings_save_one(SETTINGS_MAGN_CALIB, &calibration_data, sizeof(calibration_data));
-
-    /* this could do with eg:
-    if (settings_save_one(...) != 0) {
+    int ret = settings_save_one(SETTINGS_MAGN_CALIB,
+                            &calibration_data,
+                            sizeof(calibration_data));
+    if (ret != 0) {
+        LOG_ERR("Failed to save magnetometer calibration: %d", ret);
         calib_free(calib);
-        return -EIO;
+        return ret;
     }
-    */
-
-    LOG_INF("Calibration successful");
-    LOG_INF("Offset: %.3f %.3f %.3f",
-      calibration_data.offset_x,  //new hard correction
-      calibration_data.offset_y,
-      calibration_data.offset_z);
-
-    LOG_INF("Transform:");
-    LOG_INF("%.3f %.3f %.3f", calibration_data.transform[0][0], calibration_data.transform[0][1], calibration_data.transform[0][2]);  //new soft correction
-    LOG_INF("%.3f %.3f %.3f", calibration_data.transform[1][0], calibration_data.transform[1][1], calibration_data.transform[1][2]);
-    LOG_INF("%.3f %.3f %.3f", calibration_data.transform[2][0], calibration_data.transform[2][1], calibration_data.transform[2][2]);
-
-
-
-
-
-
 
     calib_free(calib);
 
@@ -534,61 +425,15 @@ int zsw_magnetometer_get_all(float *x, float *y, float *z)
 }
 
 
-
-
-
-/*
-
-debug only function that bypasses the sensor
-dummy samples
-library fit
-save settings
-later reads use the created matrix.
-nb this provides both hard and soft correction
-
-https://github.com/michal34512/Magnetometer-calibration
-
-Vendor the source files
-
-sensor_calibration.c/.h
-ellipsoid_fit.c/.h
-eigen.c/.h
-qr.c/.h
-matrix.c/.h
-vector.c/.h
-
-copied into new folder src/ext/magnetometer_calibration/
-
-Then add them to the Zephyr build with CMakeLists.txt.
-
-For a dummy calibration path, just use a handful of points that obviously aren't centered
-
-temporarily call dummy function from zsw_magnetometer_start_calibration()
-
-*/
-
-
-/*
-lib guves me:
-Callibration_t calib
-calib.offset      // Vector *
-calib.transform   // Matrix *
-
-But zsw wants:
-magn_calib_data_t calibration_data;
-
-*/
-
-static void copy_offset_and_matrix_to_calibration_data( //converting to zsw friendly format
-    const Callibration_t calib)
+static void copy_offset_and_matrix_to_calibration_data(
+    const Calibration_t calib)
 {
 
-    //convert hard
+
     calibration_data.offset_x = VEC_X(calib.offset);
     calibration_data.offset_y = VEC_Y(calib.offset);
     calibration_data.offset_z = VEC_Z(calib.offset);
 
-    //convert soft
     for (int r = 0; r < 3; r++) {
         for (int c = 0; c < 3; c++) {
             calibration_data.transform[r][c] =

--- a/app/src/sensors/zsw_magnetometer.c
+++ b/app/src/sensors/zsw_magnetometer.c
@@ -218,17 +218,19 @@ static void lis2mdl_trigger_handler(const struct device *dev,
 
 
 int zsw_magnetometer_get_calibration_progress(int *px, int *py, int *pz)
-  {
+
+{
     if (!px || !py || !pz) {
         return -EINVAL;
-    }
+}
 
     *px = cal_progress_x;
     *py = cal_progress_y;
     *pz = cal_progress_z;
 
     return 0;
-  }
+
+}
 
 
 
@@ -386,6 +388,10 @@ int zsw_magnetometer_compute_compensation(void)
     Vector vz = vec_from_array(cal_z, cal_sample_count);
 
     Calibration_t calib = calib_calibrate_sensor(vx, vy, vz);
+
+    vec_from_array_free(vx);
+    vec_from_array_free(vy);
+    vec_from_array_free(vz);
 
     if (!calib_calibration_success(calib)) {
         calib_free(calib);

--- a/app/src/sensors/zsw_magnetometer.c
+++ b/app/src/sensors/zsw_magnetometer.c
@@ -31,6 +31,10 @@
 #include "events/magnetometer_event.h"
 #include "sensors/zsw_magnetometer.h"
 
+#include "sensor_calibration.h"
+#include "vector.h"
+#include "matrix.h"
+
 LOG_MODULE_REGISTER(zsw_magnetometer, CONFIG_ZSW_SENSORS_LOG_LEVEL);
 
 #ifndef M_PI
@@ -41,11 +45,25 @@ LOG_MODULE_REGISTER(zsw_magnetometer, CONFIG_ZSW_SENSORS_LOG_LEVEL);
 #define SETTINGS_KEY_CALIB              "calibr"
 #define SETTINGS_MAGN_CALIB             SETTINGS_NAME_MAGN "/" SETTINGS_KEY_CALIB
 
+#define CONFIG_BOARD_NATIVE_SIM
+
 typedef struct {
-    float offset_x;
+    float offset_x; //for hard correction
     float offset_y;
     float offset_z;
+    float transform[3][3]; //for soft correction
 } magn_calib_data_t;
+
+static magn_calib_data_t calibration_data = { //transform needs an identity default
+    .transform = {
+        {1.0f, 0.0f, 0.0f},
+        {0.0f, 1.0f, 0.0f},
+        {0.0f, 0.0f, 1.0f},
+    },
+};
+
+static void copy_offset_and_matrix_to_calibration_data(
+    const Callibration_t calib);
 
 static double last_x;
 static double last_y;
@@ -56,8 +74,80 @@ static double max_z;
 static double min_x;
 static double min_y;
 static double min_z;
-static bool is_calibrating;
-static magn_calib_data_t calibration_data;
+static bool getting_data;
+static bool calibration_ready;
+
+#ifdef CONFIG_BOARD_NATIVE_SIM
+static int dummy_count;
+#endif
+
+#define CAL_MIN_RANGE 20.0 // Axis range required for 100% progress; tune on hardware.
+
+#define CAL_SAMPLE_MAX 200 // Max calibration samples to retain; tune on hardware if needed.
+
+static double cal_x[CAL_SAMPLE_MAX];
+static double cal_y[CAL_SAMPLE_MAX];
+static double cal_z[CAL_SAMPLE_MAX];
+static int cal_sample_count;
+
+
+
+
+
+static int axis_progress(double min, double max)
+{
+    double range = max - min;
+    int progress = (int)((range * 100.0) / CAL_MIN_RANGE);
+
+    return MIN(progress, 100);
+}
+
+//dummy parametric ellipsoid calibration data as have no hardware for data gathering
+
+#define DUMMY_N 80
+
+double dummy_x[DUMMY_N], dummy_y[DUMMY_N], dummy_z[DUMMY_N];
+
+static void debug_fill_dummy_samples(double x[], double y[], double z[])
+{
+    const double ox = 8.0, oy = -5.0, oz = 3.0;
+    const double ax = 40.0, by = 25.0, cz = 15.0;
+
+
+    /*
+
+    I verified the ellipsoid fitting using synthetic magnetometer data generated from a known ellipsoid with hard-iron offsets (8, -5, 3) and axis radii (40, 25, 15)
+    The recovered hard-iron offsets matched the synthetic offsets
+    The recovered scale factors matched the expected inverse axis scaling (1/40, 1/25, 1/15), transforming the ellipsoid back into a unit sphere
+
+
+
+
+    */
+
+
+
+    for (int i = 0; i < DUMMY_N; i++) {
+        double t = (2.0 * M_PI * i) / DUMMY_N;
+        double p = M_PI * ((i * 37) % DUMMY_N) / DUMMY_N;
+
+        x[i] = ox + ax * cos(t) * sin(p);
+        y[i] = oy + by * sin(t) * sin(p);
+        z[i] = oz + cz * cos(p);
+    }
+
+    //for (int i = 0; i < DUMMY_N; i++) {
+    //printf("%f\n", dummy_x[i]);
+    //}
+      //ok so below shows the same sample format as the library used
+      /*
+      8.000000
+      47.600286
+      ...
+
+      */
+
+}
 
 static void zbus_periodic_slow_callback(const struct zbus_channel *chan);
 
@@ -100,12 +190,13 @@ static void lis2mdl_trigger_handler(const struct device *dev,
             sensor_value_to_float(&magn[0]),
             sensor_value_to_float(&magn[2]));
 
-    // Convert Guass to micro Tesla
+    // Convert Gauss to micro Tesla
     last_x = sensor_value_to_float(&magn[1]) * 10; // Swap x, y to match IMU orientation
     last_y = sensor_value_to_float(&magn[0]) * 10;
     last_z = sensor_value_to_float(&magn[2]) * 10;
 
-    if (is_calibrating) {
+    /* gathering data for subsequent calibration */
+    if (getting_data) {
         if (last_x < min_x) {
             min_x = last_x;
         }
@@ -126,12 +217,55 @@ static void lis2mdl_trigger_handler(const struct device *dev,
         if (last_z > max_z) {
             max_z = last_z;
         }
+
+        if (cal_sample_count < CAL_SAMPLE_MAX) {  //storing real data
+            cal_x[cal_sample_count] = last_x;
+            cal_y[cal_sample_count] = last_y;
+            cal_z[cal_sample_count] = last_z;
+            cal_sample_count++;
+        }
+
+
+
+        int px = axis_progress(min_x, max_x);
+        int py = axis_progress(min_y, max_y);
+        int pz = axis_progress(min_z, max_z);
+
+        compass_ui_set_calibration_progress(px, py, pz);
+
+        calibration_ready =
+        (px == 100) &&
+        (py == 100) &&
+        (pz == 100);
+
     }
 
-    last_x = last_x - calibration_data.offset_x;
-    last_y = last_y - calibration_data.offset_y;
-    last_z = last_z - calibration_data.offset_z;
-}
+    /* apply last known Hard-iron correction */
+    const double x = last_x - calibration_data.offset_x;
+    const double y = last_y - calibration_data.offset_y;
+    const double z = last_z - calibration_data.offset_z;
+
+    /* apply last known Soft-iron correction */
+    last_x =
+        calibration_data.transform[0][0] * x +
+        calibration_data.transform[0][1] * y +
+        calibration_data.transform[0][2] * z;
+
+    last_y =
+        calibration_data.transform[1][0] * x +
+        calibration_data.transform[1][1] * y +
+        calibration_data.transform[1][2] * z;
+
+    last_z =
+        calibration_data.transform[2][0] * x +
+        calibration_data.transform[2][1] * y +
+        calibration_data.transform[2][2] * z;
+
+    LOG_DBG("Corrected magn: %.3f %.3f %.3f",
+            last_x, last_y, last_z);
+    }
+
+
 
 static int magn_cal_load(const char *p_key, size_t len,
                          settings_read_cb read_cb, void *p_cb_arg, void *p_param)
@@ -223,11 +357,20 @@ int zsw_magnetometer_set_enable(bool enabled)
     return 0;
 }
 
-int zsw_magnetometer_start_calibration(void)
+int zsw_magnetometer_gather_data(void)
 {
+    calibration_ready = false;
+    cal_sample_count = 0;
+
+    //commented out as on simulator
+    /*
     if (!device_is_ready(magnetometer)) {
         return -ENODEV;
     }
+    */
+    #ifdef CONFIG_BOARD_NATIVE_SIM
+    dummy_count = 0;
+    #endif
 
     max_x = -100000;
     max_y = -100000;
@@ -235,26 +378,147 @@ int zsw_magnetometer_start_calibration(void)
     min_x = 100000;
     min_y = 100000;
     min_z = 100000;
-    is_calibrating = true;
+
+    getting_data = true;  //trigger data gathering part of lis2mdl_trigger_handler
 
     return 0;
 }
 
-int zsw_magnetometer_stop_calibration(void)
+bool zsw_magnetometer_calibration_ready(void) //exercising the whole UI flow without hardware
 {
-    if (!device_is_ready(magnetometer)) {
-        return -ENODEV;
+#ifdef CONFIG_BOARD_NATIVE_SIM
+
+    dummy_count++;
+    return dummy_count > 20;   // ready after ~20 timer ticks
+
+#else
+    return calibration_ready;
+#endif
+}
+
+int zsw_magnetometer_compute_compensation(void)   //this used to be called zsw_magnetometer_stop_calibration
+{
+
+
+    //calibration_data.offset_x = (max_x + min_x) / 2;  //old simple method
+    //calibration_data.offset_y = (max_y + min_y) / 2;
+    //calibration_data.offset_z = (max_z + min_z) / 2;
+
+
+
+
+
+
+
+    //return 1;
+
+    //commented out as on simulator
+    //if (!device_is_ready(magnetometer)) {
+        //return -ENODEV;
+    //}
+
+    getting_data = false;
+
+    //following hard and soft calibration method from https://github.com/michal34512/Magnetometer-calibration
+    //LOG_INF("dummy: creating vectors");
+
+    //debug_fill_dummy_samples(dummy_x, dummy_y, dummy_z);
+
+    //Vector vx = vec_from_array(dummy_x, DUMMY_N);
+    //Vector vy = vec_from_array(dummy_y, DUMMY_N);
+    //Vector vz = vec_from_array(dummy_z, DUMMY_N);
+
+
+
+
+    //running on real data
+
+
+    Vector vx = vec_from_array(cal_x, cal_sample_count);
+    Vector vy = vec_from_array(cal_y, cal_sample_count);
+    Vector vz = vec_from_array(cal_z, cal_sample_count);
+
+    LOG_INF("Data: running fit");
+    Callibration_t calib = calib_calibrate_sensor(vx, vy, vz);
+
+
+
+
+
+
+    /*
+    //checking the end result of the compensation:
+
+    <pre>[00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: Calibration successful
+    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: Offset: 8.000 -5.000 3.000 //stored but not applied hard iron cal paramaters
+    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: Transform:
+    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: 0.025 0.000 0.000  //stored but not applied soft iron cal parameters
+    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: 0.000 0.040 0.000
+    [00:00:04.908,400] &lt;inf&gt; zsw_magnetometer: 0.000 0.000 0.067
+    </pre>
+
+
+
+
+    //soft iron ie distortion
+    The corrected points should lie on a sphere.
+
+
+
+    //hard iron re offset
+    The corrected points should be centred approximately at (0, 0, 0)
+
+
+
+
+
+
+    */
+
+
+    LOG_INF("dummy: success=%d", calib_calibration_success(calib));
+    if (!calib_calibration_success(calib)) {
+        calib_free(calib);
+        return -EINVAL;
     }
 
-    is_calibrating = false;
-    calibration_data.offset_x = (max_x + min_x) / 2;
-    calibration_data.offset_y = (max_y + min_y) / 2;
-    calibration_data.offset_z = (max_z + min_z) / 2;
+    LOG_INF("dummy: copying result");
+    copy_offset_and_matrix_to_calibration_data(calib);
 
-    settings_save_one(SETTINGS_MAGN_CALIB, &calibration_data, sizeof(magn_calib_data_t));
+    LOG_INF("dummy: saving settings");
+    settings_save_one(SETTINGS_MAGN_CALIB, &calibration_data, sizeof(calibration_data));
+
+    /* this could do with eg:
+    if (settings_save_one(...) != 0) {
+        calib_free(calib);
+        return -EIO;
+    }
+    */
+
+    LOG_INF("Calibration successful");
+    LOG_INF("Offset: %.3f %.3f %.3f",
+      calibration_data.offset_x,  //new hard correction
+      calibration_data.offset_y,
+      calibration_data.offset_z);
+
+    LOG_INF("Transform:");
+    LOG_INF("%.3f %.3f %.3f", calibration_data.transform[0][0], calibration_data.transform[0][1], calibration_data.transform[0][2]);  //new soft correction
+    LOG_INF("%.3f %.3f %.3f", calibration_data.transform[1][0], calibration_data.transform[1][1], calibration_data.transform[1][2]);
+    LOG_INF("%.3f %.3f %.3f", calibration_data.transform[2][0], calibration_data.transform[2][1], calibration_data.transform[2][2]);
+
+
+
+
+
+
+
+    calib_free(calib);
 
     return 0;
 }
+
+
+
 
 int zsw_magnetometer_get_all(float *x, float *y, float *z)
 {
@@ -267,4 +531,68 @@ int zsw_magnetometer_get_all(float *x, float *y, float *z)
     *z = last_z;
 
     return 0;
+}
+
+
+
+
+
+/*
+
+debug only function that bypasses the sensor
+dummy samples
+library fit
+save settings
+later reads use the created matrix.
+nb this provides both hard and soft correction
+
+https://github.com/michal34512/Magnetometer-calibration
+
+Vendor the source files
+
+sensor_calibration.c/.h
+ellipsoid_fit.c/.h
+eigen.c/.h
+qr.c/.h
+matrix.c/.h
+vector.c/.h
+
+copied into new folder src/ext/magnetometer_calibration/
+
+Then add them to the Zephyr build with CMakeLists.txt.
+
+For a dummy calibration path, just use a handful of points that obviously aren't centered
+
+temporarily call dummy function from zsw_magnetometer_start_calibration()
+
+*/
+
+
+/*
+lib guves me:
+Callibration_t calib
+calib.offset      // Vector *
+calib.transform   // Matrix *
+
+But zsw wants:
+magn_calib_data_t calibration_data;
+
+*/
+
+static void copy_offset_and_matrix_to_calibration_data( //converting to zsw friendly format
+    const Callibration_t calib)
+{
+
+    //convert hard
+    calibration_data.offset_x = VEC_X(calib.offset);
+    calibration_data.offset_y = VEC_Y(calib.offset);
+    calibration_data.offset_z = VEC_Z(calib.offset);
+
+    //convert soft
+    for (int r = 0; r < 3; r++) {
+        for (int c = 0; c < 3; c++) {
+            calibration_data.transform[r][c] =
+                MAT_ELEM(calib.transform, r, c);
+        }
+    }
 }

--- a/app/src/sensors/zsw_magnetometer.h
+++ b/app/src/sensors/zsw_magnetometer.h
@@ -37,3 +37,6 @@ bool zsw_magnetometer_calibration_ready(void);
 int zsw_magnetometer_get_all(float *x, float *y, float *z);
 int zsw_magnetometer_gather_data(void);
 int zsw_magnetometer_compute_compensation(void);
+bool zsw_magnetometer_recalibration_required(void);
+int zsw_magnetometer_cancel_calibration(void);
+int zsw_magnetometer_get_calibration_progress(int *px, int *py, int *pz);

--- a/app/src/sensors/zsw_magnetometer.h
+++ b/app/src/sensors/zsw_magnetometer.h
@@ -21,7 +21,6 @@
 
 int zsw_magnetometer_init(void);
 int zsw_magnetometer_set_enable(bool enabled);
-double zsw_magnetometer_get_heading(void);  //is not defined, below is used instead
 bool zsw_magnetometer_calibration_ready(void);
 /*
 * Get the magnetometer data in micro Tesla.

--- a/app/src/sensors/zsw_magnetometer.h
+++ b/app/src/sensors/zsw_magnetometer.h
@@ -21,11 +21,11 @@
 
 int zsw_magnetometer_init(void);
 int zsw_magnetometer_set_enable(bool enabled);
-double zsw_magnetometer_get_heading(void);
-
+double zsw_magnetometer_get_heading(void);  //is not defined, below is used instead
+bool zsw_magnetometer_calibration_ready(void);
 /*
 * Get the magnetometer data in micro Tesla.
-* Divide with 10 to get it in Guass.
+* Divide with 10 to get it in Gauss.
 *
 * @param x Pointer to the x-axis data.
 * @param y Pointer to the y-axis data.
@@ -35,5 +35,5 @@ double zsw_magnetometer_get_heading(void);
 
 */
 int zsw_magnetometer_get_all(float *x, float *y, float *z);
-int zsw_magnetometer_start_calibration(void);
-int zsw_magnetometer_stop_calibration(void);
+int zsw_magnetometer_gather_data(void);
+int zsw_magnetometer_compute_compensation(void);


### PR DESCRIPTION
Added hard and soft iron compensation with user calibration interface 
# Testing
### Compensation algorithm testing
- Used both hard-iron and soft-iron compensation from https://github.com/michal34512/Magnetometer-calibration
- Verified ellipsoid fitting using synthetic magnetometer data generated from a known ellipsoid with centre offset (8, -5, 3) and axis radii (40, 25, 15).
- Recovered hard-iron offsets matching the synthetic offsets.
- Recovered soft-iron scale factors matched the expected inverse axis scaling: 1/40, 1/25, 1/15

### UX testing
- Tested the calibration UI flow in native_sim using temporary dummy calibration data/progress generation.
- Verified progress bars, success/failure popup handling, timeout handling, repeated calibration, and cleanup.
- Temporary dummy test code was removed before commit.

Please note: CAL_MIN_RANGE and CAL_SAMPLE_MAX may need tuning based on real hardware testing.

<img width="471" height="499" alt="zsw_pic_bars" src="https://github.com/user-attachments/assets/73227dea-a549-4a45-ac93-1fc9a41e4d52" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive magnetometer calibration: calibration overlay with real-time X/Y/Z progress bars, start/gather/cancel flow, and success/timeout popups.
  * Automatic sample collection with live progress reporting, readiness check, and one-step compensation computation that is persisted.
  * Legacy/invalid calibration storage now prompts recalibration rather than failing initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->