### PR TITLE
ui: add queued popup handling with static FIFO pool and API docs

### DIFF
--- a/app/src/ui/popup/zsw_popup_window.c
+++ b/app/src/ui/popup/zsw_popup_window.c
@@ -20,6 +20,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/spinlock.h>
 
 #include "managers/zsw_power_manager.h"
 #include "ui/popup/zsw_popup_window.h"
@@ -51,6 +52,7 @@ static lv_obj_t *yes_btn;
 static lv_obj_t *no_btn;
 static lv_timer_t *auto_close_timer;
 static bool popup_active;
+static struct k_spinlock popup_lock;
 
 static popup_request_t current_popup;
 
@@ -89,7 +91,6 @@ static void show_popup_request(popup_request_t *req)
     lv_obj_t *close_btn = NULL;
 
     current_popup = *req;
-    popup_active = true;
     zsw_power_manager_reset_idle_timout();
 
     mbox = lv_msgbox_create(lv_layer_top());
@@ -157,7 +158,6 @@ static void finalize_current_popup(bool confirmed)
 
     yes_btn = NULL;
     no_btn = NULL;
-    popup_active = false;
 
     if (finished_cb) {
         finished_cb(confirmed);
@@ -165,7 +165,17 @@ static void finalize_current_popup(bool confirmed)
 
     if (mbox == NULL) {
         popup_request_t next_popup;
+        bool has_next = false;
+
+        k_spinlock_key_t key = k_spin_lock(&popup_lock);
         if (k_msgq_get(&pending_popup_msgq, &next_popup, K_NO_WAIT) == 0) {
+            has_next = true;
+        } else {
+            popup_active = false;
+        }
+        k_spin_unlock(&popup_lock, key);
+
+        if (has_next) {
             show_popup_request(&next_popup);
         }
     }
@@ -183,13 +193,18 @@ void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint3
     copy_text_to_request(req.title, sizeof(req.title), title, "title");
     copy_text_to_request(req.body, sizeof(req.body), body, "body");
 
+    k_spinlock_key_t key = k_spin_lock(&popup_lock);
     if (popup_active) {
         int ret = k_msgq_put(&pending_popup_msgq, &req, K_NO_WAIT);
+        k_spin_unlock(&popup_lock, key);
         if (ret != 0) {
             LOG_WRN("Popup queue full, dropping popup");
         }
         return;
     }
+    
+    popup_active = true;
+    k_spin_unlock(&popup_lock, key);
 
     show_popup_request(&req);
 }

--- a/app/src/ui/popup/zsw_popup_window.c
+++ b/app/src/ui/popup/zsw_popup_window.c
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <string.h>
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
@@ -30,8 +31,6 @@ LOG_MODULE_REGISTER(zsw_popup_window, LOG_LEVEL_INF);
 #define POPUP_BODY_MAX_LEN       192
 
 typedef struct popup_request {
-    /* k_fifo links items through the first word, so it must stay first. */
-    void *fifo_reserved;
     char title[POPUP_TITLE_MAX_LEN];
     char body[POPUP_BODY_MAX_LEN];
     on_close_popup_cb_t close_cb;
@@ -44,56 +43,26 @@ static void on_popup_close_button_pressed(lv_event_t *e);
 static void close_popup_timer(lv_timer_t *timer);
 static void finalize_current_popup(bool confirmed);
 static void show_popup_request(popup_request_t *req);
-static void init_popup_queue(void);
-static popup_request_t *acquire_popup_request_slot(void);
-static void release_popup_request_slot(popup_request_t *req);
 static void copy_text_to_request(char *dst, size_t dst_size, const char *src, const char *name);
+static int popup_queue_init(void);
 
 static lv_obj_t *mbox;
 static lv_obj_t *yes_btn;
 static lv_obj_t *no_btn;
 static lv_timer_t *auto_close_timer;
+static bool popup_active;
 
-static bool popup_queue_initialized;
-static popup_request_t popup_request_pool[POPUP_QUEUE_SIZE];
-static popup_request_t *current_popup;
+static popup_request_t current_popup;
 
-/* Separate free/pending FIFOs avoid dynamic allocation while keeping FIFO order. */
-K_FIFO_DEFINE(free_popup_fifo);
-K_FIFO_DEFINE(pending_popup_fifo);
+K_MSGQ_DEFINE(pending_popup_msgq, sizeof(popup_request_t), POPUP_QUEUE_SIZE, 4);
 
-static void init_popup_queue(void)
+static int popup_queue_init(void)
 {
-    if (popup_queue_initialized) {
-        return;
-    }
-
-    for (int i = 0; i < POPUP_QUEUE_SIZE; i++) {
-        k_fifo_put(&free_popup_fifo, &popup_request_pool[i]);
-    }
-
-    popup_queue_initialized = true;
+    k_msgq_purge(&pending_popup_msgq);
+    return 0;
 }
 
-static popup_request_t *acquire_popup_request_slot(void)
-{
-    return k_fifo_get(&free_popup_fifo, K_NO_WAIT);
-}
-
-static void release_popup_request_slot(popup_request_t *req)
-{
-    if (!req) {
-        return;
-    }
-
-    req->title[0] = '\0';
-    req->body[0] = '\0';
-    req->close_cb = NULL;
-    req->close_after_seconds = 0;
-    req->display_yes_no = false;
-
-    k_fifo_put(&free_popup_fifo, req);
-}
+SYS_INIT(popup_queue_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 
 static void copy_text_to_request(char *dst, size_t dst_size, const char *src, const char *name)
 {
@@ -115,15 +84,18 @@ static void copy_text_to_request(char *dst, size_t dst_size, const char *src, co
 
 static void show_popup_request(popup_request_t *req)
 {
+    __ASSERT_NO_MSG(req != NULL);
+
     lv_obj_t *close_btn = NULL;
 
-    current_popup = req;
+    current_popup = *req;
+    popup_active = true;
     zsw_power_manager_reset_idle_timout();
 
     mbox = lv_msgbox_create(lv_layer_top());
-    lv_msgbox_add_title(mbox, current_popup->title);
-    lv_msgbox_add_text(mbox, current_popup->body);
-    if (current_popup->display_yes_no) {
+    lv_msgbox_add_title(mbox, current_popup.title);
+    lv_msgbox_add_text(mbox, current_popup.body);
+    if (current_popup.display_yes_no) {
         yes_btn = lv_msgbox_add_footer_button(mbox, "Yes");
         no_btn = lv_msgbox_add_footer_button(mbox, "No");
         lv_obj_add_event_cb(yes_btn, on_popup_button_pressed, LV_EVENT_CLICKED, NULL);
@@ -156,69 +128,78 @@ static void show_popup_request(popup_request_t *req)
         lv_obj_add_style(close_btn, &color_style, 0);
     }
 
-    auto_close_timer = lv_timer_create(close_popup_timer, current_popup->close_after_seconds * 1000,  NULL);
-    lv_timer_set_repeat_count(auto_close_timer, 1);
+    if (current_popup.close_after_seconds > 0) {
+        auto_close_timer = lv_timer_create(close_popup_timer, current_popup.close_after_seconds * 1000, NULL);
+        lv_timer_set_repeat_count(auto_close_timer, 1);
+    } else {
+        auto_close_timer = NULL;
+    }
 }
 
 static void finalize_current_popup(bool confirmed)
 {
-    popup_request_t *finished_popup = current_popup;
+    on_close_popup_cb_t finished_cb = NULL;
+
+    if (!popup_active) {
+        return;
+    }
+
+    finished_cb = current_popup.close_cb;
 
     if (mbox) {
         if (auto_close_timer) {
             lv_timer_del(auto_close_timer);
             auto_close_timer = NULL;
         }
-        lv_msgbox_close(mbox);
+        lv_obj_delete_async(mbox);
         mbox = NULL;
     }
 
     yes_btn = NULL;
     no_btn = NULL;
-    current_popup = NULL;
+    popup_active = false;
 
-    if (finished_popup && finished_popup->close_cb) {
-        /* Callback is fired before slot recycling to preserve request context. */
-        finished_popup->close_cb(confirmed);
+    if (finished_cb) {
+        finished_cb(confirmed);
     }
 
-    release_popup_request_slot(finished_popup);
-
-    popup_request_t *next_popup = k_fifo_get(&pending_popup_fifo, K_NO_WAIT);
-    if (next_popup) {
-        show_popup_request(next_popup);
+    if (mbox == NULL) {
+        popup_request_t next_popup;
+        if (k_msgq_get(&pending_popup_msgq, &next_popup, K_NO_WAIT) == 0) {
+            show_popup_request(&next_popup);
+        }
     }
 }
 
 void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
                     bool display_yes_no)
 {
-    popup_request_t *req;
+    popup_request_t req = {
+        .close_cb = close_cb,
+        .close_after_seconds = close_after_seconds,
+        .display_yes_no = display_yes_no,
+    };
 
-    init_popup_queue();
+    copy_text_to_request(req.title, sizeof(req.title), title, "title");
+    copy_text_to_request(req.body, sizeof(req.body), body, "body");
 
-    req = acquire_popup_request_slot();
-    if (!req) {
-        LOG_WRN("Popup queue full, dropping popup");
+    if (popup_active) {
+        int ret = k_msgq_put(&pending_popup_msgq, &req, K_NO_WAIT);
+        if (ret != 0) {
+            LOG_WRN("Popup queue full, dropping popup");
+        }
         return;
     }
 
-    copy_text_to_request(req->title, sizeof(req->title), title, "title");
-    copy_text_to_request(req->body, sizeof(req->body), body, "body");
-    req->close_cb = close_cb;
-    req->close_after_seconds = close_after_seconds;
-    req->display_yes_no = display_yes_no;
-
-    if (mbox) {
-        k_fifo_put(&pending_popup_fifo, req);
-        return;
-    }
-
-    show_popup_request(req);
+    show_popup_request(&req);
 }
 
 void zsw_popup_remove(void)
 {
+    if (!popup_active) {
+        return;
+    }
+
     finalize_current_popup(false);
 }
 
@@ -232,10 +213,12 @@ static void on_popup_button_pressed(lv_event_t *e)
 
 static void on_popup_close_button_pressed(lv_event_t *e)
 {
+    LV_UNUSED(e);
     finalize_current_popup(false);
 }
 
 static void close_popup_timer(lv_timer_t *timer)
 {
+    LV_UNUSED(timer);
     finalize_current_popup(false);
 }

--- a/app/src/ui/popup/zsw_popup_window.c
+++ b/app/src/ui/popup/zsw_popup_window.c
@@ -15,34 +15,115 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
 #include "managers/zsw_power_manager.h"
 #include "ui/popup/zsw_popup_window.h"
+
+LOG_MODULE_REGISTER(zsw_popup_window, LOG_LEVEL_INF);
+
+#define POPUP_QUEUE_SIZE         8
+#define POPUP_TITLE_MAX_LEN      64
+#define POPUP_BODY_MAX_LEN       192
+
+typedef struct popup_request {
+    /* k_fifo links items through the first word, so it must stay first. */
+    void *fifo_reserved;
+    char title[POPUP_TITLE_MAX_LEN];
+    char body[POPUP_BODY_MAX_LEN];
+    on_close_popup_cb_t close_cb;
+    uint32_t close_after_seconds;
+    bool display_yes_no;
+} popup_request_t;
 
 static void on_popup_button_pressed(lv_event_t *e);
 static void on_popup_close_button_pressed(lv_event_t *e);
 static void close_popup_timer(lv_timer_t *timer);
+static void finalize_current_popup(bool confirmed);
+static void show_popup_request(popup_request_t *req);
+static void init_popup_queue(void);
+static popup_request_t *acquire_popup_request_slot(void);
+static void release_popup_request_slot(popup_request_t *req);
+static void copy_text_to_request(char *dst, size_t dst_size, const char *src, const char *name);
 
 static lv_obj_t *mbox;
 static lv_obj_t *yes_btn;
 static lv_obj_t *no_btn;
-static on_close_popup_cb_t on_close_cb;
 static lv_timer_t *auto_close_timer;
 
-void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
-                    bool display_yes_no)
+static bool popup_queue_initialized;
+static popup_request_t popup_request_pool[POPUP_QUEUE_SIZE];
+static popup_request_t *current_popup;
+
+/* Separate free/pending FIFOs avoid dynamic allocation while keeping FIFO order. */
+K_FIFO_DEFINE(free_popup_fifo);
+K_FIFO_DEFINE(pending_popup_fifo);
+
+static void init_popup_queue(void)
 {
-    if (mbox) {
-        // TODO handle queue of popups
+    if (popup_queue_initialized) {
         return;
     }
-    zsw_power_manager_reset_idle_timout();
-    on_close_cb = close_cb;
+
+    for (int i = 0; i < POPUP_QUEUE_SIZE; i++) {
+        k_fifo_put(&free_popup_fifo, &popup_request_pool[i]);
+    }
+
+    popup_queue_initialized = true;
+}
+
+static popup_request_t *acquire_popup_request_slot(void)
+{
+    return k_fifo_get(&free_popup_fifo, K_NO_WAIT);
+}
+
+static void release_popup_request_slot(popup_request_t *req)
+{
+    if (!req) {
+        return;
+    }
+
+    req->title[0] = '\0';
+    req->body[0] = '\0';
+    req->close_cb = NULL;
+    req->close_after_seconds = 0;
+    req->display_yes_no = false;
+
+    k_fifo_put(&free_popup_fifo, req);
+}
+
+static void copy_text_to_request(char *dst, size_t dst_size, const char *src, const char *name)
+{
+    size_t src_len;
+
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+
+    src_len = strlen(src);
+    if (src_len >= dst_size) {
+        LOG_WRN("Popup %s truncated (%u >= %u)", name, (uint32_t)src_len, (uint32_t)dst_size);
+    }
+
+    strncpy(dst, src, dst_size - 1);
+    dst[dst_size - 1] = '\0';
+}
+
+static void show_popup_request(popup_request_t *req)
+{
     lv_obj_t *close_btn = NULL;
 
+    current_popup = req;
+    zsw_power_manager_reset_idle_timout();
+
     mbox = lv_msgbox_create(lv_layer_top());
-    lv_msgbox_add_title(mbox, title);
-    lv_msgbox_add_text(mbox, body);
-    if (display_yes_no) {
+    lv_msgbox_add_title(mbox, current_popup->title);
+    lv_msgbox_add_text(mbox, current_popup->body);
+    if (current_popup->display_yes_no) {
         yes_btn = lv_msgbox_add_footer_button(mbox, "Yes");
         no_btn = lv_msgbox_add_footer_button(mbox, "No");
         lv_obj_add_event_cb(yes_btn, on_popup_button_pressed, LV_EVENT_CLICKED, NULL);
@@ -75,17 +156,70 @@ void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint3
         lv_obj_add_style(close_btn, &color_style, 0);
     }
 
-    auto_close_timer = lv_timer_create(close_popup_timer, close_after_seconds * 1000,  NULL);
+    auto_close_timer = lv_timer_create(close_popup_timer, current_popup->close_after_seconds * 1000,  NULL);
     lv_timer_set_repeat_count(auto_close_timer, 1);
+}
+
+static void finalize_current_popup(bool confirmed)
+{
+    popup_request_t *finished_popup = current_popup;
+
+    if (mbox) {
+        if (auto_close_timer) {
+            lv_timer_del(auto_close_timer);
+            auto_close_timer = NULL;
+        }
+        lv_msgbox_close(mbox);
+        mbox = NULL;
+    }
+
+    yes_btn = NULL;
+    no_btn = NULL;
+    current_popup = NULL;
+
+    if (finished_popup && finished_popup->close_cb) {
+        /* Callback is fired before slot recycling to preserve request context. */
+        finished_popup->close_cb(confirmed);
+    }
+
+    release_popup_request_slot(finished_popup);
+
+    popup_request_t *next_popup = k_fifo_get(&pending_popup_fifo, K_NO_WAIT);
+    if (next_popup) {
+        show_popup_request(next_popup);
+    }
+}
+
+void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
+                    bool display_yes_no)
+{
+    popup_request_t *req;
+
+    init_popup_queue();
+
+    req = acquire_popup_request_slot();
+    if (!req) {
+        LOG_WRN("Popup queue full, dropping popup");
+        return;
+    }
+
+    copy_text_to_request(req->title, sizeof(req->title), title, "title");
+    copy_text_to_request(req->body, sizeof(req->body), body, "body");
+    req->close_cb = close_cb;
+    req->close_after_seconds = close_after_seconds;
+    req->display_yes_no = display_yes_no;
+
+    if (mbox) {
+        k_fifo_put(&pending_popup_fifo, req);
+        return;
+    }
+
+    show_popup_request(req);
 }
 
 void zsw_popup_remove(void)
 {
-    if (mbox) {
-        lv_timer_del(auto_close_timer);
-        lv_msgbox_close(mbox);
-        mbox = NULL;
-    }
+    finalize_current_popup(false);
 }
 
 static void on_popup_button_pressed(lv_event_t *e)
@@ -93,30 +227,15 @@ static void on_popup_button_pressed(lv_event_t *e)
     lv_obj_t *target = lv_event_get_target_obj(e);
     bool is_yes_btn = (target == yes_btn);
 
-    zsw_popup_remove();
-    if (is_yes_btn) {
-        if (on_close_cb) {
-            on_close_cb(true);
-        }
-    } else {
-        if (on_close_cb) {
-            on_close_cb(false);
-        }
-    }
+    finalize_current_popup(is_yes_btn);
 }
 
 static void on_popup_close_button_pressed(lv_event_t *e)
 {
-    zsw_popup_remove();
-    if (on_close_cb) {
-        on_close_cb(false);
-    }
+    finalize_current_popup(false);
 }
 
 static void close_popup_timer(lv_timer_t *timer)
 {
-    zsw_popup_remove();
-    if (on_close_cb) {
-        on_close_cb(false);
-    }
+    finalize_current_popup(false);
 }

--- a/app/src/ui/popup/zsw_popup_window.c
+++ b/app/src/ui/popup/zsw_popup_window.c
@@ -202,7 +202,7 @@ void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint3
         }
         return;
     }
-    
+
     popup_active = true;
     k_spin_unlock(&popup_lock, key);
 

--- a/app/src/ui/popup/zsw_popup_window.h
+++ b/app/src/ui/popup/zsw_popup_window.h
@@ -19,8 +19,23 @@
 
 #include <lvgl.h>
 
+/** @brief Callback fired when a popup closes.
+ *  @param confirmed true only when the user pressed "Yes".
+ */
 typedef void(*on_close_popup_cb_t)(bool confirmed);
 
+/** @brief Show a popup on the top layer.
+ *  Requests are queued when another popup is already visible.
+ *  @param title Popup title string.
+ *  @param body Popup body string.
+ *  @param close_cb Callback called when popup closes.
+ *  @param close_after_seconds Auto-close timeout in seconds.
+ *  @param display_yes_no true to show Yes/No buttons, false for close button.
+ */
 void zsw_popup_show(char *title, char *body, on_close_popup_cb_t close_cb, uint32_t close_after_seconds,
                     bool display_yes_no);
+
+/** @brief Remove the active popup.
+ *  If queued requests exist, the next popup is shown automatically.
+ */
 void zsw_popup_remove(void);

--- a/app/src/ui/popup/zsw_popup_window.h
+++ b/app/src/ui/popup/zsw_popup_window.h
@@ -26,6 +26,9 @@ typedef void(*on_close_popup_cb_t)(bool confirmed);
 
 /** @brief Show a popup on the top layer.
  *  Requests are queued when another popup is already visible.
+ *  The pending queue holds at most 8 requests; additional requests are dropped
+ *  and only a warning is logged.
+ *  close_after_seconds == 0 disables auto-close.
  *  @param title Popup title string.
  *  @param body Popup body string.
  *  @param close_cb Callback called when popup closes.


### PR DESCRIPTION
Implemented queue support for zsw_popup_window to fix lost popups when one is already visible (Issue #535 ).

What was done:

1. Added a bounded static FIFO queue (8 slots) for popup requests.
2. Each queued request stores the required show arguments (title, body, callback, timeout, and yes/no mode).
3. Refactored popup completion flow so all close paths (yes/no, close button, timeout, and explicit remove) use one finalize path.
4. After a popup is finalized, the next queued popup is shown automatically.
5. Added clear drop behavior when queue is full: new request is dropped and a warning is logged.
6. Added concise API/implementation documentation in project Doxygen style.

What this solves:

1. Prevents silent loss of popup requests while another popup is active.
2. Preserves FIFO display order for pending popups.
3. Keeps callback behavior consistent for shown popups (confirmed only on Yes, false otherwise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added queued popup support so multiple prompts are shown sequentially.
  * Popups support configurable close behavior, Yes/No buttons, callbacks, and automatic timeouts.
  * The next queued popup appears automatically when the active popup is dismissed or times out.
  * Excess popup requests are safely dropped when the queue is full.

* **Documentation**
  * Clarified popup callbacks, dismissal behavior, queue limits, and removal semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->